### PR TITLE
Switch redis to valkey

### DIFF
--- a/redis/Dockerfile
+++ b/redis/Dockerfile
@@ -1,20 +1,22 @@
 FROM fedora:latest
 
 RUN \
-   groupadd -r -g 1001 redis && \
-   useradd -r -g redis -u 1001 -s /sbin/nologin redis
+   groupadd -r -g 1001 valkey && \
+   useradd -r -g valkey -u 1001 -s /sbin/nologin valkey
 
-RUN dnf -y update && dnf install -y redis && dnf clean all
+RUN dnf -y update && dnf install -y valkey && dnf clean all
 
-RUN chmod 0770 /etc/redis
+RUN chmod 0770 /etc/valkey
 
-RUN mkdir -m 0770 /data && chown redis:0 /data
+RUN mkdir -m 0770 /data && chown valkey:0 /data
 VOLUME /data
 WORKDIR /data
+
+RUN mkdir /var/run/valkey && chown valkey:0 /var/run/valkey
 
 COPY docker-entrypoint.sh /usr/local/bin/
 ENTRYPOINT ["docker-entrypoint.sh"]
 
 USER 1001
 EXPOSE 6379
-CMD ["redis-server"]
+CMD ["valkey-server"]

--- a/redis/docker-entrypoint.sh
+++ b/redis/docker-entrypoint.sh
@@ -1,19 +1,19 @@
 #!/bin/sh
 
-cat /etc/redis/redis.conf | \
+cat /etc/valkey/valkey.conf | \
     sed \
 	-e 's@^dir .*@dir /data@' \
 	-e 's@^logfile .*@logfile ""@' \
 	-e 's@^bind @# bind @' \
-        > /etc/redis/redis-docker.conf
+        > /etc/valkey/valkey-docker.conf
 
 if [ "${REDIS_PASSWORD+set}" = "set" ] ; then
-    echo "requirepass ${REDIS_PASSWORD}" >> /etc/redis/redis-docker.conf
+    echo "requirepass ${REDIS_PASSWORD}" >> /etc/valkey/valkey-docker.conf
 fi
 
-if [ "$1" = "redis-server" ] ; then
+if [ "$1" = "valkey-server" ] ; then
     shift
-    set -- redis-server /etc/redis/redis-docker.conf "$@"
+    set -- valkey-server /etc/valkey/valkey-docker.conf "$@"
 fi
 
 exec "$@"

--- a/tools/run-redis.sh
+++ b/tools/run-redis.sh
@@ -8,7 +8,7 @@ podman run \
         --rm --user 0:0 \
         -v $topdir/work/redis-data:/data:z \
         flatpak-indexer-redis \
-        chown redis:redis /data
+        chown valkey:valkey /data
 
 exec podman run \
         -e REDIS_PASSWORD=abc123 \


### PR DESCRIPTION
The latest fedora doesn't have redis package anymore. Let's use valkey instead.