### PR TITLE
Reformat codebase with Ruff

### DIFF
--- a/flatpak_indexer/bodhi_query.py
+++ b/flatpak_indexer/bodhi_query.py
@@ -207,7 +207,7 @@ def _refresh_updates(session: Session, content_type, entities, pipe, rows_per_pa
     to_query = set(entities)
     to_refresh = set()
 
-    current_ts = datetime.utcnow().replace(tzinfo=timezone.utc)
+    current_ts = datetime.now(tz=timezone.utc)
 
     queried_ts = pipe.hmget("update-cache:" + content_type, *entities)
     parsed_ts = [parse_date(ts.decode("utf-8")) if ts else None for ts in queried_ts]
@@ -269,7 +269,7 @@ def _refresh_all_updates(session: Session, content_type, pipe, rows_per_page=10)
     assert isinstance(session.config, HttpConfig)
     requests_session = session.config.get_requests_session()
 
-    current_ts = datetime.utcnow()
+    current_ts = datetime.now(tz=timezone.utc)
 
     cache_ts = pipe.hget("update-cache:" + content_type, "@ALL@")
     if cache_ts:
@@ -415,7 +415,7 @@ def query_releases(session: Session):
             elif state == "archived":
                 status = ReleaseStatus.EOL
             else:
-                logger.warn("Unknown state for release %s: %s", name, state)
+                logger.warning("Unknown state for release %s: %s", name, state)
                 continue
 
             result.append(Release(name=name, branch=branch, tag=name.lower(), status=status))

--- a/flatpak_indexer/bodhi_query.py
+++ b/flatpak_indexer/bodhi_query.py
@@ -1,8 +1,8 @@
 from datetime import datetime, timedelta, timezone
 from functools import partial
+from typing import Any, Dict, List, Union
 import logging
 import re
-from typing import Any, Dict, List, Union
 
 from .http_utils import HttpConfig
 from .models import BodhiUpdateModel
@@ -29,11 +29,11 @@ TIMESTAMP_FUZZ = timedelta(minutes=1)
 
 
 def parse_date_value(value):
-    return datetime.strptime(value, '%Y-%m-%d %H:%M:%S').replace(tzinfo=timezone.utc)
+    return datetime.strptime(value, "%Y-%m-%d %H:%M:%S").replace(tzinfo=timezone.utc)
 
 
 def _update_update_from_response(pipe, update_json, old_update: BodhiUpdateModel):
-    content_type = update_json['content_type']
+    content_type = update_json["content_type"]
 
     if old_update:
         old_entities = {nvr.name for nvr in old_update.builds}
@@ -44,52 +44,52 @@ def _update_update_from_response(pipe, update_json, old_update: BodhiUpdateModel
         if date:
             return parse_date_value(date)
 
-    update = BodhiUpdateModel(update_id=update_json['updateid'],
-                              release_name=update_json['release']['name'],
-                              release_branch=update_json['release']['branch'],
-                              date_submitted=parse_date(update_json['date_submitted']),
-                              date_testing=parse_date(update_json['date_testing']),
-                              date_stable=parse_date(update_json['date_stable']),
-                              user_name=update_json['user']['name'],
-                              status=update_json['status'],
-                              type=update_json['type'])
+    update = BodhiUpdateModel(
+        update_id=update_json["updateid"],
+        release_name=update_json["release"]["name"],
+        release_branch=update_json["release"]["branch"],
+        date_submitted=parse_date(update_json["date_submitted"]),
+        date_testing=parse_date(update_json["date_testing"]),
+        date_stable=parse_date(update_json["date_stable"]),
+        user_name=update_json["user"]["name"],
+        status=update_json["status"],
+        type=update_json["type"],
+    )
 
-    for build_json in update_json['builds']:
-        update.builds.append(NVR(build_json['nvr']))
+    for build_json in update_json["builds"]:
+        update.builds.append(NVR(build_json["nvr"]))
 
     new_entities = {nvr.name for nvr in update.builds}
 
     def _entity_key(entity_name):
-        return entity_name + ':' + update.release_branch + ':' + update.update_id
+        return entity_name + ":" + update.release_branch + ":" + update.update_id
 
-    pipe.set('update:' + update.update_id, update.to_json_text())
+    pipe.set("update:" + update.update_id, update.to_json_text())
     to_remove = [_entity_key(e) for e in old_entities - new_entities]
     if to_remove:
-        pipe.zrem('updates-by-entity:' + content_type, *to_remove)
+        pipe.zrem("updates-by-entity:" + content_type, *to_remove)
     to_add = {_entity_key(e): 0 for e in new_entities - old_entities}
     if to_add:
-        pipe.zadd('updates-by-entity:' + content_type, to_add)
+        pipe.zadd("updates-by-entity:" + content_type, to_add)
 
 
 def _load_old_updates(pipe, results):
     old_updates = {}
     if results:
-        old_updates_raw = pipe.mget(*('update:' + r['updateid'] for r in results))
+        old_updates_raw = pipe.mget(*("update:" + r["updateid"] for r in results))
         for result, old_update_raw in zip(results, old_updates_raw):
             if old_update_raw:
-                old_updates[result['updateid']] = BodhiUpdateModel.from_json_text(old_update_raw)
+                old_updates[result["updateid"]] = BodhiUpdateModel.from_json_text(old_update_raw)
 
     return old_updates
 
 
 def _update_updates_from_response(pipe, results, old_updates):
     for result in results:
-        _update_update_from_response(pipe, result, old_updates.get(result['updateid']))
+        _update_update_from_response(pipe, result, old_updates.get(result["updateid"]))
 
 
-def _run_query(requests_session,
-               content_type, url, params, save_entities,
-               results):
+def _run_query(requests_session, content_type, url, params, save_entities, results):
     # Depending on our query parameters, we might get duplicates in the response, and might
     # get less than rows_per_page rows in the response
     # (https://github.com/fedora-infra/bodhi/issues/4130),
@@ -98,27 +98,26 @@ def _run_query(requests_session,
     seen_updates = set()
     page = 1
     while True:
-        params['page'] = page
+        params["page"] = page
         logger.info("Querying Bodhi with params: %s", params)
 
-        response = requests_session.get(url,
-                                        headers={'Accept': 'application/json'},
-                                        params=params)
+        response = requests_session.get(url, headers={"Accept": "application/json"}, params=params)
         response.raise_for_status()
         response_json = response.json()
 
-        for update_json in response_json['updates']:
-            update_id = update_json['updateid']
+        for update_json in response_json["updates"]:
+            update_id = update_json["updateid"]
             if update_id in seen_updates:
                 continue
 
             seen_updates.add(update_id)
 
             found_build = False
-            for build_json in update_json['builds']:
-                package_name = build_json['nvr'].rsplit('-', 2)[0]
-                if (build_json['type'] == content_type and
-                        (save_entities is None or package_name in save_entities)):
+            for build_json in update_json["builds"]:
+                package_name = build_json["nvr"].rsplit("-", 2)[0]
+                if build_json["type"] == content_type and (
+                    save_entities is None or package_name in save_entities
+                ):
                     found_build = True
             if not found_build:
                 continue
@@ -127,23 +126,25 @@ def _run_query(requests_session,
 
         # The first check avoids an extra round trip in the normal case, the second check
         # avoids paging forever if something goes wrong
-        if len(seen_updates) >= response_json['total'] or len(response_json['updates']) == 0:
+        if len(seen_updates) >= response_json["total"] or len(response_json["updates"]) == 0:
             break
         else:
             page += 1
 
 
-def _query_updates(session: Session,
-                   requests_session,
-                   content_type, results,
-                   query_entities=None,
-                   save_entities=None,
-                   after=None,
-                   rows_per_page=100):
-
+def _query_updates(
+    session: Session,
+    requests_session,
+    content_type,
+    results,
+    query_entities=None,
+    save_entities=None,
+    after=None,
+    rows_per_page=100,
+):
     url = "https://bodhi.fedoraproject.org/updates/"
     params: Dict[str, Union[int, str, List[str]]] = {
-        'rows_per_page': rows_per_page,
+        "rows_per_page": rows_per_page,
     }
 
     bodhi_releases: List[str] = []
@@ -152,10 +153,10 @@ def _query_updates(session: Session,
             continue
 
         bodhi_release = release.name
-        if content_type == 'flatpak':
-            bodhi_release += 'F'
+        if content_type == "flatpak":
+            bodhi_release += "F"
         bodhi_releases.append(bodhi_release)
-    params['releases'] = bodhi_releases
+    params["releases"] = bodhi_releases
 
     # Setting the content type in the query:
     #
@@ -173,34 +174,32 @@ def _query_updates(session: Session,
     if query_entities is not None:
         if len(query_entities) > 5:
             for i in range(0, len(query_entities), 5):
-                _query_updates(session, requests_session,
-                               content_type, results,
-                               query_entities=query_entities[i:i+5],
-                               save_entities=save_entities,
-                               after=after,
-                               rows_per_page=rows_per_page)
+                _query_updates(
+                    session,
+                    requests_session,
+                    content_type,
+                    results,
+                    query_entities=query_entities[i : i + 5],
+                    save_entities=save_entities,
+                    after=after,
+                    rows_per_page=rows_per_page,
+                )
             return
         else:
-            params['packages'] = query_entities
+            params["packages"] = query_entities
 
     if after is not None:
-        for key in ['submitted_since', 'modified_since']:
+        for key in ["submitted_since", "modified_since"]:
             params_copy = dict(params)
             params_copy[key] = (after - TIMESTAMP_FUZZ).isoformat()
 
-            _run_query(requests_session,
-                       content_type,
-                       url, params_copy, save_entities,
-                       results)
+            _run_query(requests_session, content_type, url, params_copy, save_entities, results)
     else:
-        _run_query(requests_session,
-                   content_type,
-                   url, params, save_entities,
-                   results)
+        _run_query(requests_session, content_type, url, params, save_entities, results)
 
 
 def _refresh_updates(session: Session, content_type, entities, pipe, rows_per_page=None):
-    pipe.watch('updates-by-entity:' + content_type)
+    pipe.watch("updates-by-entity:" + content_type)
 
     assert isinstance(session.config, HttpConfig)
     requests_session = session.config.get_requests_session()
@@ -210,7 +209,7 @@ def _refresh_updates(session: Session, content_type, entities, pipe, rows_per_pa
 
     current_ts = datetime.utcnow().replace(tzinfo=timezone.utc)
 
-    queried_ts = pipe.hmget('update-cache:' + content_type, *entities)
+    queried_ts = pipe.hmget("update-cache:" + content_type, *entities)
     parsed_ts = [parse_date(ts.decode("utf-8")) if ts else None for ts in queried_ts]
 
     results: List[Dict[str, Any]] = []
@@ -225,18 +224,26 @@ def _refresh_updates(session: Session, content_type, entities, pipe, rows_per_pa
                         to_query.remove(entity_name)
 
         if len(to_refresh) > 0:
-            _query_updates(session, requests_session,
-                           content_type, results,
-                           save_entities=to_refresh,
-                           after=refresh_ts - TIMESTAMP_FUZZ,
-                           rows_per_page=rows_per_page)
+            _query_updates(
+                session,
+                requests_session,
+                content_type,
+                results,
+                save_entities=to_refresh,
+                after=refresh_ts - TIMESTAMP_FUZZ,
+                rows_per_page=rows_per_page,
+            )
 
     if len(to_query) > 0:
-        _query_updates(session, requests_session,
-                       content_type, results,
-                       query_entities=sorted(to_query),
-                       save_entities=to_query,
-                       rows_per_page=rows_per_page)
+        _query_updates(
+            session,
+            requests_session,
+            content_type,
+            results,
+            query_entities=sorted(to_query),
+            save_entities=to_query,
+            rows_per_page=rows_per_page,
+        )
 
     old_updates = _load_old_updates(pipe, results)
 
@@ -245,45 +252,41 @@ def _refresh_updates(session: Session, content_type, entities, pipe, rows_per_pa
     _update_updates_from_response(pipe, results, old_updates)
 
     formatted_current_ts = format_date(current_ts)
-    pipe.hset('update-cache:' + content_type, mapping={
-        e: formatted_current_ts for e in entities
-    })
+    pipe.hset("update-cache:" + content_type, mapping={e: formatted_current_ts for e in entities})
 
     pipe.execute()
 
 
-def refresh_updates(session: Session,
-                    content_type, entities, rows_per_page=10):
+def refresh_updates(session: Session, content_type, entities, rows_per_page=10):
     session.redis_client.transaction(
         partial(_refresh_updates, session, content_type, entities, rows_per_page=rows_per_page)
     )
 
 
 def _refresh_all_updates(session: Session, content_type, pipe, rows_per_page=10):
-    pipe.watch('updates-by-entity:' + content_type)
+    pipe.watch("updates-by-entity:" + content_type)
 
     assert isinstance(session.config, HttpConfig)
     requests_session = session.config.get_requests_session()
 
     current_ts = datetime.utcnow()
 
-    cache_ts = pipe.hget('update-cache:' + content_type, '@ALL@')
+    cache_ts = pipe.hget("update-cache:" + content_type, "@ALL@")
     if cache_ts:
         after = parse_date(cache_ts.decode("utf-8")) - TIMESTAMP_FUZZ
     else:
         after = None
 
     results: List[Dict[str, Any]] = []
-    _query_updates(session, requests_session,
-                   content_type, results,
-                   after=after,
-                   rows_per_page=rows_per_page)
+    _query_updates(
+        session, requests_session, content_type, results, after=after, rows_per_page=rows_per_page
+    )
 
     old_updates = _load_old_updates(pipe, results)
 
     pipe.multi()
     _update_updates_from_response(pipe, results, old_updates)
-    pipe.hset('update-cache:' + content_type, '@ALL@', format_date(current_ts))
+    pipe.hset("update-cache:" + content_type, "@ALL@", format_date(current_ts))
     pipe.execute()
 
 
@@ -294,7 +297,7 @@ def refresh_all_updates(session, content_type, rows_per_page=10):
 
 
 def _refresh_update(update_json, pipe):
-    pipe.watch('updates-by-entity:' + update_json['content_type'])
+    pipe.watch("updates-by-entity:" + update_json["content_type"])
 
     results = [update_json]
     old_updates = _load_old_updates(pipe, results)
@@ -311,50 +314,52 @@ def refresh_update_status(session, update_id):
     assert isinstance(session.config, HttpConfig)
     requests_session = session.config.get_requests_session()
 
-    if session.redis_client.get('update:' + update_id) is None:
+    if session.redis_client.get("update:" + update_id) is None:
         logger.info("Update %s not found, no need to update status", update_id)
         return
 
     logger.info("Querying bodhi for the new status of: %s", update_id)
-    response = requests_session.get(url,
-                                    headers={'Accept': 'application/json'})
+    response = requests_session.get(url, headers={"Accept": "application/json"})
     response.raise_for_status()
 
     # Could optimize to avoid updating the updates-by-entity index
-    session.redis_client.transaction(partial(_refresh_update, response.json()['update']))
+    session.redis_client.transaction(partial(_refresh_update, response.json()["update"]))
 
 
 def reset_update_cache(session):
-    session.redis_client.delete('update-cache:flatpak')
-    session.redis_client.delete('update-cache:rpm')
+    session.redis_client.delete("update-cache:flatpak")
+    session.redis_client.delete("update-cache:rpm")
 
 
 def list_updates(session, content_type, entity_name=None, release_branch=None):
-    """ Returns a list of (PackageUpdateBuild, PackageBuild)"""
+    """Returns a list of (PackageUpdateBuild, PackageBuild)"""
 
     if release_branch is not None:
         branches = [release_branch]
     else:
-        branches = [r.branch for r in session.fedora_releases if
-                    r.status != ReleaseStatus.EOL and r.status != ReleaseStatus.RAWHIDE]
+        branches = [
+            r.branch
+            for r in session.fedora_releases
+            if r.status != ReleaseStatus.EOL and r.status != ReleaseStatus.RAWHIDE
+        ]
 
     if entity_name is not None:
         key = entity_name
 
-        first_key = key + ':' + branches[0]
-        last_key = key + ':' + branches[-1]
+        first_key = key + ":" + branches[0]
+        last_key = key + ":" + branches[-1]
 
         updates_by_entity = session.redis_client.zrangebylex(
-            'updates-by-entity:' + content_type, '[' + first_key + ':', '(' + last_key + ';'
+            "updates-by-entity:" + content_type, "[" + first_key + ":", "(" + last_key + ";"
         )
     else:
-        updates_by_entity = session.redis_client.zrange('updates-by-entity:' + content_type, 0, -1)
+        updates_by_entity = session.redis_client.zrange("updates-by-entity:" + content_type, 0, -1)
 
     def filter_results(keys):
         for key in keys:
             entity_name, rb, update_id = key.decode("utf-8").split(":")
             if release_branch is None or rb in branches:
-                yield 'update:' + update_id
+                yield "update:" + update_id
 
     # Remove duplicates
     to_fetch = sorted(set(filter_results(updates_by_entity)))
@@ -383,9 +388,7 @@ def query_releases(session: Session):
     while True:
         params["page"] = page
         logger.info("Querying Bodhi with params: %s", params)
-        response = requests_session.get(url,
-                                        headers={"Accept": "application/json"},
-                                        params=params)
+        response = requests_session.get(url, headers={"Accept": "application/json"}, params=params)
         response.raise_for_status()
         response_json = response.json()
 
@@ -415,12 +418,7 @@ def query_releases(session: Session):
                 logger.warn("Unknown state for release %s: %s", name, state)
                 continue
 
-            result.append(Release(
-                name=name,
-                branch=branch,
-                tag=name.lower(),
-                status=status
-            ))
+            result.append(Release(name=name, branch=branch, tag=name.lower(), status=status))
 
         if page == int(response_json["pages"]):
             break

--- a/flatpak_indexer/build_cache.py
+++ b/flatpak_indexer/build_cache.py
@@ -1,9 +1,7 @@
 from typing import Dict
 
 from .koji_query import query_image_build, query_module_build, query_package_build
-from .models import (
-    ImageBuildModel, ModuleBuildModel, PackageBuildModel
-)
+from .models import ImageBuildModel, ModuleBuildModel, PackageBuildModel
 from .session import Session
 
 

--- a/flatpak_indexer/cleaner.py
+++ b/flatpak_indexer/cleaner.py
@@ -1,16 +1,15 @@
 from datetime import datetime
+from typing import List
 import logging
 import os
-from typing import List
 
 from .models import TardiffResultModel
 from .redis_utils import get_redis_client
 from .utils import path_for_digest
 
-
 logger = logging.getLogger(__name__)
 
-FILES_USED_KEY = 'files:used'
+FILES_USED_KEY = "files:used"
 CLEAN_RESULTS_BATCH_SIZE = 50
 
 
@@ -25,6 +24,7 @@ class Cleaner:
     The second part allows clean_files_after: 0d to mean "no grace period" instead
     of "delete all files immediately"
     """
+
     def __init__(self, config):
         self.config = config
         self.redis = get_redis_client(config)
@@ -62,16 +62,15 @@ class Cleaner:
         keys = list(self.redis.scan_iter(match="tardiff:result:*"))
 
         for pos in range(0, len(keys), CLEAN_RESULTS_BATCH_SIZE):
-            batch_keys = keys[pos:pos + CLEAN_RESULTS_BATCH_SIZE]
+            batch_keys = keys[pos : pos + CLEAN_RESULTS_BATCH_SIZE]
             results_raw = self.redis.mget(*batch_keys)
 
             to_delete = []
             for key, result_raw in zip(batch_keys, results_raw):
                 assert result_raw is not None
                 result = TardiffResultModel.from_json_text(result_raw)
-                if result.status == 'success':
-                    path = path_for_digest(self.config.deltas_dir,
-                                           result.digest, '.tardiff')
+                if result.status == "success":
+                    path = path_for_digest(self.config.deltas_dir, result.digest, ".tardiff")
                     if path not in self.this_cycle and path not in current:
                         logger.info("Removing %s for %s", key, path)
                         to_delete.append(key)

--- a/flatpak_indexer/cli.py
+++ b/flatpak_indexer/cli.py
@@ -1,6 +1,6 @@
+from typing import Dict
 import logging
 import time
-from typing import Dict
 
 import click
 
@@ -11,33 +11,30 @@ from .differ import Differ
 from .indexer import Indexer
 from .models import RegistryModel
 
-
 logger = logging.getLogger(__name__)
 
 
 @click.group()
 @click.pass_context
-@click.option('--config-file', '-c', required=True,
-              help='Config file')
-@click.option('-v', '--verbose', is_flag=True,
-              help='Show verbose debugging output')
+@click.option("--config-file", "-c", required=True, help="Config file")
+@click.option("-v", "--verbose", is_flag=True, help="Show verbose debugging output")
 def cli(ctx, config_file, verbose):
     cfg = Config.from_path(config_file)
 
     ctx.obj = {
-        'config': cfg,
+        "config": cfg,
     }
 
     FORMAT = "%(asctime)s:%(levelname)s:%(name)s:%(message)s"
     logging.basicConfig(level=logging.WARNING, format=FORMAT)
     if verbose:
-        logging.getLogger('flatpak_indexer').setLevel(logging.INFO)
+        logging.getLogger("flatpak_indexer").setLevel(logging.INFO)
 
 
 @cli.command(name="daemon")
 @click.pass_context
 def daemon(ctx):
-    cfg = ctx.obj['config']
+    cfg = ctx.obj["config"]
 
     cleaner = Cleaner(cfg)
     updaters = load_updaters(cfg)
@@ -50,9 +47,13 @@ def daemon(ctx):
         last_update_time = None
         while True:
             if last_update_time is not None:
-                time.sleep(max(0,
-                               cfg.daemon.update_interval.total_seconds()
-                               - (time.time() - last_update_time)))
+                time.sleep(
+                    max(
+                        0,
+                        cfg.daemon.update_interval.total_seconds()
+                        - (time.time() - last_update_time),
+                    )
+                )
             last_update_time = time.time()
 
             registry_data: Dict[str, RegistryModel] = {}
@@ -84,7 +85,7 @@ def daemon(ctx):
 @cli.command(name="differ")
 @click.pass_context
 def differ(ctx):
-    cfg = ctx.obj['config']
+    cfg = ctx.obj["config"]
 
     differ = Differ(cfg)
     differ.run()
@@ -93,7 +94,7 @@ def differ(ctx):
 @cli.command(name="index")
 @click.pass_context
 def index(ctx):
-    cfg = ctx.obj['config']
+    cfg = ctx.obj["config"]
 
     updaters = load_updaters(cfg)
     indexer = Indexer(cfg)

--- a/flatpak_indexer/config.py
+++ b/flatpak_indexer/config.py
@@ -1,13 +1,13 @@
-import copy
 from datetime import timedelta
+from typing import Dict, List, Optional, Tuple
+import copy
 import os
 import re
-from typing import Dict, List, Optional, Tuple
 
-from flatpak_indexer.koji_utils import KojiConfig
-from flatpak_indexer.odcs_query import OdcsConfig
-from flatpak_indexer.redis_utils import RedisConfig
-from .base_config import BaseConfig, ConfigError, configfield, Lookup
+from .base_config import BaseConfig, ConfigError, Lookup, configfield
+from .koji_utils import KojiConfig
+from .odcs_query import OdcsConfig
+from .redis_utils import RedisConfig
 
 
 class RegistryConfig(BaseConfig):
@@ -40,10 +40,12 @@ class PyxisRegistryConfig(RegistryConfig):
         if self.pyxis_client_cert and self.pyxis_client_key:
             if not os.path.exists(self.pyxis_client_cert):
                 raise ConfigError(
-                    "pyxis_client_cert: {} does not exist".format(self.pyxis_client_cert))
+                    "pyxis_client_cert: {} does not exist".format(self.pyxis_client_cert)
+                )
             if not os.path.exists(self.pyxis_client_key):
                 raise ConfigError(
-                    "pyxis_client_key: {} does not exist".format(self.pyxis_client_key))
+                    "pyxis_client_key: {} does not exist".format(self.pyxis_client_key)
+                )
 
         if (not self.repository_parse) != (not self.repository_replace):
             raise ConfigError(
@@ -55,9 +57,11 @@ class PyxisRegistryConfig(RegistryConfig):
 
     def adjust_repository(self, repository_name: str):
         if self.repository_parse and self.repository_replace:
-            return re.sub('^' + self.repository_parse + '$',
-                          self.repository_replace,
-                          repository_name)
+            return re.sub(
+                "^" + self.repository_parse + "$",
+                self.repository_replace,
+                repository_name,
+            )
         else:
             return repository_name
 
@@ -91,9 +95,9 @@ class IndexConfig(BaseConfig):
         self.name = name
         super().__init__(lookup)
 
-        delta_keep = lookup.get_timedelta('delta_keep', None)
+        delta_keep = lookup.get_timedelta("delta_keep", None)
         if delta_keep is None:
-            delta_keep_days = lookup.get_int('delta_keep_days', 0)
+            delta_keep_days = lookup.get_int("delta_keep_days", 0)
             delta_keep = timedelta(days=delta_keep_days)
         self.delta_keep = delta_keep
 
@@ -171,8 +175,8 @@ class Config(KojiConfig, OdcsConfig, RedisConfig):
         if self.deltas_dir is not None and self.deltas_uri is None:
             raise ConfigError("deltas_dir is configured, but not deltas_uri")
 
-        for name, sublookup in lookup.iterate_objects('registries'):
-            datasource = sublookup.get_str('datasource')
+        for name, sublookup in lookup.iterate_objects("registries"):
+            datasource = sublookup.get_str("datasource")
 
             if datasource == "pyxis":
                 registry_config = PyxisRegistryConfig(name, sublookup)
@@ -181,55 +185,75 @@ class Config(KojiConfig, OdcsConfig, RedisConfig):
             elif datasource == "fedora":
                 registry_config = FedoraRegistryConfig(name, sublookup)
             else:
-                raise ConfigError("registry/{}: datasource must be 'pyxis', 'koji', or 'fedora'"
-                                  .format(name))
+                raise ConfigError(
+                    "registry/{}: datasource must be 'pyxis', 'koji', or 'fedora'".format(name)
+                )
 
             self.registries[name] = registry_config
 
         tag_koji_tags: Dict[str, Tuple[str, List[str]]] = dict()
 
-        for name, sublookup in lookup.iterate_objects('indexes'):
+        for name, sublookup in lookup.iterate_objects("indexes"):
             index_config = IndexConfig(name, sublookup)
 
             registry_config2 = self.registries.get(index_config.registry)
             if not registry_config2:
-                raise ConfigError("indexes/{}: No registry config found for {}"
-                                  .format(index_config.name, index_config.registry))
+                raise ConfigError(
+                    "indexes/{}: No registry config found for {}".format(
+                        index_config.name, index_config.registry
+                    )
+                )
 
             if index_config.extract_icons and self.icons_dir is None:
-                raise ConfigError("indexes/{}: extract_icons is set, but no icons_dir is configured"
-                                  .format(index_config.name))
+                raise ConfigError(
+                    "indexes/{}: extract_icons is set, but no icons_dir is configured".format(
+                        index_config.name
+                    )
+                )
 
             if index_config.delta_keep.total_seconds() > 0:
                 if self.deltas_dir is None:
-                    raise ConfigError(("indexes/{}: delta_keep is set, " +
-                                       "but no deltas_dir is configured")
-                                      .format(index_config.name))
+                    raise ConfigError(
+                        ("indexes/{}: delta_keep is set, but no deltas_dir is configured").format(
+                            index_config.name
+                        )
+                    )
 
-            if registry_config2.datasource == 'pyxis':
+            if registry_config2.datasource == "pyxis":
                 if index_config.bodhi_status is not None:
-                    raise ConfigError(("indexes/{}: bodhi_status can only be set " +
-                                       "for the fedora datasource")
-                                      .format(index_config.name))
+                    raise ConfigError(
+                        (
+                            "indexes/{}: bodhi_status can only be set for the fedora datasource"
+                        ).format(index_config.name)
+                    )
 
-            if registry_config2.datasource == 'fedora':
-                if index_config.bodhi_status not in ('testing', 'stable'):
-                    raise ConfigError(("indexes/{}: bodhi_status must be set " +
-                                       "to 'testing' or 'stable'")
-                                      .format(index_config.name))
+            if registry_config2.datasource == "fedora":
+                if index_config.bodhi_status not in ("testing", "stable"):
+                    raise ConfigError(
+                        ("indexes/{}: bodhi_status must be set to 'testing' or 'stable'").format(
+                            index_config.name
+                        )
+                    )
 
                 if index_config.koji_tags:
-                    raise ConfigError(("indexes/{}: koji_tags can only be set " +
-                                       "for the pyxis datasource")
-                                      .format(index_config.name))
+                    raise ConfigError(
+                        ("indexes/{}: koji_tags can only be set for the pyxis datasource").format(
+                            index_config.name
+                        )
+                    )
 
             if index_config.tag in tag_koji_tags:
                 old_name, old_koji_tags = tag_koji_tags[index_config.tag]
                 if set(old_koji_tags) != set(index_config.koji_tags):
-                    raise ConfigError(f"indexes/{old_name}, indexes/{index_config.name}: "
-                                      "koji_tags must be consistent for indexes with the same tag")
+                    raise ConfigError(
+                        f"indexes/{old_name}, indexes/{index_config.name}: "
+                        "koji_tags must be consistent for indexes with the same tag"
+                    )
             else:
-                tag_koji_tags[index_config.tag] = (index_config.name, index_config.koji_tags)
+                tag_koji_tags[index_config.tag] = (
+                    index_config.name,
+                    index_config.koji_tags,
+                )
 
             if len(index_config.architecture_expand) > 0:
                 for arch_config in index_config.expand_architectures():
@@ -238,6 +262,4 @@ class Config(KojiConfig, OdcsConfig, RedisConfig):
                 self.indexes.append(index_config)
 
     def get_indexes_for_datasource(self, datasource: str):
-        return [
-            i for i in self.indexes if self.registries[i.registry].datasource == datasource
-        ]
+        return [i for i in self.indexes if self.registries[i.registry].datasource == datasource]

--- a/flatpak_indexer/datasource/__init__.py
+++ b/flatpak_indexer/datasource/__init__.py
@@ -1,21 +1,22 @@
+from abc import ABC, abstractmethod
 from typing import Dict, List
 
 from ..config import Config
 from ..models import RegistryModel
 
 
-class Updater:
-    def __init__(self, config: Config):
-        raise NotImplementedError()
+class Updater(ABC):
+    @abstractmethod
+    def __init__(self, config: Config): ...
 
-    def start(self):
-        raise NotImplementedError()
+    @abstractmethod
+    def start(self) -> None: ...
 
-    def update(self, registry_data: Dict[str, RegistryModel]):
-        raise NotImplementedError()
+    @abstractmethod
+    def update(self, registry_data: Dict[str, RegistryModel]) -> None: ...
 
-    def stop(self):
-        raise NotImplementedError()
+    @abstractmethod
+    def stop(self) -> None: ...
 
 
 def load_updaters(config) -> List[Updater]:

--- a/flatpak_indexer/datasource/__init__.py
+++ b/flatpak_indexer/datasource/__init__.py
@@ -27,16 +27,19 @@ def load_updaters(config) -> List[Updater]:
 
     updaters: List[Updater] = []
 
-    if 'fedora' in datasources:
+    if "fedora" in datasources:
         from .fedora import FedoraUpdater
+
         updaters.append(FedoraUpdater(config))
 
-    if 'koji' in datasources:
+    if "koji" in datasources:
         from .koji import KojiUpdater
+
         updaters.append(KojiUpdater(config))
 
-    if 'pyxis' in datasources:
+    if "pyxis" in datasources:
         from .pyxis import PyxisUpdater
+
         updaters.append(PyxisUpdater(config))
 
     return updaters

--- a/flatpak_indexer/datasource/fedora/updater.py
+++ b/flatpak_indexer/datasource/fedora/updater.py
@@ -3,17 +3,25 @@ from typing import DefaultDict, Dict, List, NamedTuple, Optional, Set
 
 import redis
 
-from .. import Updater
-from ...bodhi_query import (list_updates, refresh_all_updates,
-                            refresh_update_status, reset_update_cache)
+from ...bodhi_query import (
+    list_updates,
+    refresh_all_updates,
+    refresh_update_status,
+    reset_update_cache,
+)
 from ...config import Config
 from ...fedora_monitor import FedoraMonitor
 from ...models import (
-    BodhiUpdateModel, ImageBuildModel, ImageModel, RegistryModel,
-    TagHistoryItemModel, TagHistoryModel
+    BodhiUpdateModel,
+    ImageBuildModel,
+    ImageModel,
+    RegistryModel,
+    TagHistoryItemModel,
+    TagHistoryModel,
 )
 from ...session import Session
 from ...utils import unparse_pull_spec
+from .. import Updater
 
 
 class UpdateBuild(NamedTuple):
@@ -50,9 +58,7 @@ def _fix_pull_spec(image: ImageModel, registry_url: str, repo_name: str):
     # Replace the image pull spec which points to the candidate registry
     # to the final location of the image - this will be more robust if builds
     # are deleted from the candidate registry
-    image.pull_spec = unparse_pull_spec(registry_url,
-                                        repo_name,
-                                        image.digest)
+    image.pull_spec = unparse_pull_spec(registry_url, repo_name, image.digest)
 
 
 class FedoraUpdater(Updater):
@@ -86,10 +92,13 @@ class FedoraUpdater(Updater):
         # Now we've updated, we can remove old entries from the log
         self.change_monitor.clear_bodhi_changed(serial)
 
-        refresh_all_updates(session, content_type='flatpak')
-        updates = list_updates(session, content_type='flatpak')
-        builds = {nvr: session.build_cache.get_image_build(nvr)
-                  for update in updates for nvr in update.builds}
+        refresh_all_updates(session, content_type="flatpak")
+        updates = list_updates(session, content_type="flatpak")
+        builds = {
+            nvr: session.build_cache.get_image_build(nvr)
+            for update in updates
+            for nvr in update.builds
+        }
 
         repos: Dict[str, RepoInfo] = {}
 
@@ -110,30 +119,46 @@ class FedoraUpdater(Updater):
         for repo_name, repo in repos.items():
             # Find the current testing update - the status might be 'stable' if it's been
             # moved to stable afterwards
-            current_testing = max((update_build for update_build in repo.testing_updates
-                                   if update_build.update.status in ('testing', 'stable')),
-                                  key=lambda ub: ub.date_testing, default=None)
+            current_testing = max(
+                (
+                    update_build
+                    for update_build in repo.testing_updates
+                    if update_build.update.status in ("testing", "stable")
+                ),
+                key=lambda ub: ub.date_testing,
+                default=None,
+            )
 
             # Discard any updates that have date_testing after the current update - they
             # must have been unpushed from testing
-            repo.testing_updates = [update_build for update_build in repo.testing_updates
-                                    if (current_testing and
-                                        current_testing.date_testing >= update_build.date_testing)]
+            repo.testing_updates = [
+                update_build
+                for update_build in repo.testing_updates
+                if (current_testing and current_testing.date_testing >= update_build.date_testing)
+            ]
 
             # Sort the newest first
             repo.testing_updates.sort(key=lambda ub: ub.date_testing, reverse=True)
 
             # Now the same for stable
-            current_stable = max((update_build for update_build in repo.stable_updates
-                                  if update_build.update.status == 'stable'),
-                                 key=lambda ub: ub.date_stable, default=None)
-            repo.stable_updates = [update_build for update_build in repo.stable_updates
-                                   if (current_stable and
-                                       current_stable.date_stable >= update_build.date_stable)]
+            current_stable = max(
+                (
+                    update_build
+                    for update_build in repo.stable_updates
+                    if update_build.update.status == "stable"
+                ),
+                key=lambda ub: ub.date_stable,
+                default=None,
+            )
+            repo.stable_updates = [
+                update_build
+                for update_build in repo.stable_updates
+                if (current_stable and current_stable.date_stable >= update_build.date_stable)
+            ]
             repo.stable_updates.sort(key=lambda ub: ub.date_stable, reverse=True)
 
         registry_statuses: DefaultDict[str, Set[str]] = defaultdict(set)
-        for index_config in self.conf.get_indexes_for_datasource('fedora'):
+        for index_config in self.conf.get_indexes_for_datasource("fedora"):
             registry_name = index_config.registry
 
             assert index_config.bodhi_status  # config.py enforces this for fedora datasource
@@ -144,8 +169,8 @@ class FedoraUpdater(Updater):
             registry = RegistryModel()
             registry_url = self.conf.registries[registry_name].public_url
 
-            need_testing = 'testing' in registry_statuses[registry_name]
-            need_stable = 'stable' in registry_statuses[registry_name]
+            need_testing = "testing" in registry_statuses[registry_name]
+            need_stable = "stable" in registry_statuses[registry_name]
 
             for repo_name, repo in repos.items():
                 if repo.testing_updates:
@@ -158,8 +183,11 @@ class FedoraUpdater(Updater):
                     latest_stable_build = None
 
                 # Set the tags on images based on what is current
-                if (latest_testing_build and latest_stable_build and
-                        latest_testing_build is latest_stable_build):
+                if (
+                    latest_testing_build
+                    and latest_stable_build
+                    and latest_testing_build is latest_stable_build
+                ):
                     _set_build_image_tags(latest_testing_build, ["latest", "testing"])
                 else:
                     if latest_testing_build:
@@ -175,9 +203,11 @@ class FedoraUpdater(Updater):
                         for image in build.images:
                             _fix_pull_spec(image, registry_url, repo_name)
                             registry.add_image(repo_name, image)
-                            item = TagHistoryItemModel(architecture=image.architecture,
-                                                       date=update.date_testing,
-                                                       digest=image.digest)
+                            item = TagHistoryItemModel(
+                                architecture=image.architecture,
+                                date=update.date_testing,
+                                digest=image.digest,
+                            )
                             tag_history.items.append(item)
 
                     registry.repositories[repo_name].tag_histories["testing"] = tag_history
@@ -189,9 +219,11 @@ class FedoraUpdater(Updater):
                         for image in build.images:
                             _fix_pull_spec(image, registry_url, repo_name)
                             registry.add_image(repo_name, image)
-                            item = TagHistoryItemModel(architecture=image.architecture,
-                                                       date=update.date_stable,
-                                                       digest=image.digest)
+                            item = TagHistoryItemModel(
+                                architecture=image.architecture,
+                                date=update.date_stable,
+                                digest=image.digest,
+                            )
                             tag_history.items.append(item)
 
                     registry.repositories[repo_name].tag_histories["latest"] = tag_history

--- a/flatpak_indexer/delta_generator.py
+++ b/flatpak_indexer/delta_generator.py
@@ -39,7 +39,7 @@ class DeltaGenerator:
         if cleaner is None:
             cleaner = Cleaner(self.config)
         self.cleaner = cleaner
-        self.now = datetime.utcnow().replace(tzinfo=timezone.utc)
+        self.now = datetime.now(tz=timezone.utc)
         # to_digest => set(from digests)
         self.deltas: Dict[str, Set[str]] = {}
         # image digest => (ImageModel, TardiffImageModel)

--- a/flatpak_indexer/differ.py
+++ b/flatpak_indexer/differ.py
@@ -1,18 +1,18 @@
 from datetime import datetime
+from typing import cast
 import logging
 import os
 import subprocess
 import tempfile
-from typing import cast
+
+import requests
 
 import redis
-import requests
 
 from .models import TardiffResultModel, TardiffSpecModel
 from .redis_utils import do_pubsub_work, get_redis_client
 from .registry_client import RegistryClient
-from .utils import path_for_digest, run_with_stats, TemporaryPathname
-
+from .utils import TemporaryPathname, path_for_digest, run_with_stats
 
 logger = logging.getLogger(__name__)
 
@@ -28,30 +28,30 @@ class Differ:
             # Eat all available messages
             while True:
                 message = pubsub.get_message(timeout=0)
-                logging.info('%s', message)
+                logging.info("%s", message)
                 if not message:
                     break
-                if message['type'] == 'message':
+                if message["type"] == "message":
                     got_message = True
             if not got_message:
                 # Do a blocking wait
-                message = pubsub.get_message(timeout=60*60)
-                if message and message['type'] == 'message':
+                message = pubsub.get_message(timeout=60 * 60)
+                if message and message["type"] == "message":
                     got_message = True
 
     def _get_task(self):
         with self.redis_client.pipeline() as pipe:
-            pipe.watch('tardiff:pending')
+            pipe.watch("tardiff:pending")
             pre = cast("redis.Redis[bytes]", pipe)
-            task_raw = pre.srandmember('tardiff:pending')
+            task_raw = pre.srandmember("tardiff:pending")
             if task_raw is None:
                 return None
 
             task = cast(bytes, task_raw).decode("utf-8")
 
             pipe.multi()
-            pipe.srem('tardiff:pending', task)
-            pipe.zadd('tardiff:progress', {task: datetime.now().timestamp()})
+            pipe.srem("tardiff:pending", task)
+            pipe.zadd("tardiff:progress", {task: datetime.now().timestamp()})
             try:
                 pipe.execute()
                 return task
@@ -59,60 +59,77 @@ class Differ:
                 return None
 
     def _download_layer(self, image, diff_id, output_path, progress_callback=None):
-        client = RegistryClient(image.registry,
-                                session=self.config.get_requests_session())
-        client.download_layer(image.repository, image.ref, diff_id, output_path,
-                              progress_callback=progress_callback)
+        client = RegistryClient(image.registry, session=self.config.get_requests_session())
+        client.download_layer(
+            image.repository, image.ref, diff_id, output_path, progress_callback=progress_callback
+        )
 
     def _process_task(self, task):
         spec_raw = self.redis_client.get(f"tardiff:spec:{task}")
         if spec_raw is None:
             logger.warning("Can't find spec for '%s', ignoring task", task)
-            return TardiffResultModel(status="no-spec-error",
-                                      digest="",
-                                      size=0,
-                                      message="failed to find spec")
+            return TardiffResultModel(
+                status="no-spec-error", digest="", size=0, message="failed to find spec"
+            )
         spec = TardiffSpecModel.from_json_text(spec_raw)
 
-        logger.info("Processing task from=%s/%s@%s (DiffId=%s), to=%s/%s@%s (DiffId=%s)",
-                    spec.from_image.registry, spec.from_image.repository, spec.from_image.ref,
-                    spec.from_diff_id,
-                    spec.to_image.registry, spec.to_image.repository, spec.to_image.ref,
-                    spec.to_diff_id)
+        logger.info(
+            "Processing task from=%s/%s@%s (DiffId=%s), to=%s/%s@%s (DiffId=%s)",
+            spec.from_image.registry,
+            spec.from_image.repository,
+            spec.from_image.ref,
+            spec.from_diff_id,
+            spec.to_image.registry,
+            spec.to_image.repository,
+            spec.to_image.ref,
+            spec.to_diff_id,
+        )
 
-        with tempfile.TemporaryDirectory(prefix="flatpak-indexer-differ-") as tempdir, \
-             TemporaryPathname(dir=self.config.deltas_dir, suffix=".tardiff") as result_path:
+        with (
+            tempfile.TemporaryDirectory(prefix="flatpak-indexer-differ-") as tempdir,
+            TemporaryPathname(dir=self.config.deltas_dir, suffix=".tardiff") as result_path,
+        ):
             from_path = os.path.join(tempdir, "from-layer")
             to_path = os.path.join(tempdir, "to-layer")
 
             def progress(*args):
-                self.redis_client.zadd('tardiff:progress', {task: datetime.now().timestamp()})
+                self.redis_client.zadd("tardiff:progress", {task: datetime.now().timestamp()})
 
             try:
-                self._download_layer(spec.from_image, spec.from_diff_id,
-                                     from_path, progress_callback=progress)
-            except (requests.exceptions.ConnectionError,
-                    requests.exceptions.HTTPError,
-                    requests.exceptions.SSLError) as e:
+                self._download_layer(
+                    spec.from_image, spec.from_diff_id, from_path, progress_callback=progress
+                )
+            except (
+                requests.exceptions.ConnectionError,
+                requests.exceptions.HTTPError,
+                requests.exceptions.SSLError,
+            ) as e:
                 logger.info("Failed to download from layer: %s", str(e))
-                return TardiffResultModel(status="download-error",
-                                          digest="",
-                                          size=0,
-                                          message="downloading from layer failed")
+                return TardiffResultModel(
+                    status="download-error",
+                    digest="",
+                    size=0,
+                    message="downloading from layer failed",
+                )
 
             from_size = os.stat(from_path).st_size
 
             try:
-                self._download_layer(spec.to_image, spec.to_diff_id,
-                                     to_path, progress_callback=progress)
-            except (requests.exceptions.ConnectionError,
-                    requests.exceptions.HTTPError,
-                    requests.exceptions.SSLError) as e:
+                self._download_layer(
+                    spec.to_image, spec.to_diff_id, to_path, progress_callback=progress
+                )
+            except (
+                requests.exceptions.ConnectionError,
+                requests.exceptions.HTTPError,
+                requests.exceptions.SSLError,
+            ) as e:
                 logger.info("Failed to download to layer: %s", str(e))
-                return TardiffResultModel(status="download-error",
-                                          digest="",
-                                          size=0,
-                                          message="downloading to layer failed")
+                return TardiffResultModel(
+                    status="download-error",
+                    digest="",
+                    size=0,
+                    message="downloading to layer failed",
+                )
 
             to_size = os.stat(to_path).st_size
 
@@ -121,48 +138,54 @@ class Differ:
             result, stats = run_with_stats(args, progress_callback=progress)
 
             if result == 0:
-                logger.info("tar-diff: elapsed=%ss, user=%ss, system=%ss, maximum RSS=%s kIB",
-                            stats.elapsed_time_s, stats.user_time_s, stats.system_time_s,
-                            stats.max_mem_kib)
+                logger.info(
+                    "tar-diff: elapsed=%ss, user=%ss, system=%ss, maximum RSS=%s kIB",
+                    stats.elapsed_time_s,
+                    stats.user_time_s,
+                    stats.system_time_s,
+                    stats.max_mem_kib,
+                )
 
                 output = subprocess.check_output(["sha256sum", result_path.name], encoding="utf-8")
-                digest = 'sha256:' + output.strip().split()[0]
+                digest = "sha256:" + output.strip().split()[0]
                 size = os.stat(result_path.name).st_size
 
-                final_path = path_for_digest(self.config.deltas_dir,
-                                             digest, '.tardiff', create_subdir=True)
+                final_path = path_for_digest(
+                    self.config.deltas_dir, digest, ".tardiff", create_subdir=True
+                )
                 os.chmod(result_path.name, 0o644)
                 os.rename(result_path.name, final_path)
                 result_path.delete = False
 
                 logger.info("Successfully processed task")
-                result = TardiffResultModel(status="success",
-                                            digest=digest,
-                                            size=size,
-                                            message="",
-                                            from_size=from_size,
-                                            to_size=to_size,
-                                            max_mem_kib=stats.max_mem_kib,
-                                            elapsed_time_s=stats.elapsed_time_s,
-                                            user_time_s=stats.user_time_s,
-                                            system_time_s=stats.system_time_s)
+                result = TardiffResultModel(
+                    status="success",
+                    digest=digest,
+                    size=size,
+                    message="",
+                    from_size=from_size,
+                    to_size=to_size,
+                    max_mem_kib=stats.max_mem_kib,
+                    elapsed_time_s=stats.elapsed_time_s,
+                    user_time_s=stats.user_time_s,
+                    system_time_s=stats.system_time_s,
+                )
             else:
                 logger.info("tar-diff exited with status=%d", result)
-                result = TardiffResultModel(status="diff-error",
-                                            digest="",
-                                            size=0,
-                                            message="tardiff failed")
+                result = TardiffResultModel(
+                    status="diff-error", digest="", size=0, message="tardiff failed"
+                )
 
             return result
 
     def _finish_task(self, task, result):
         with self.redis_client.pipeline() as pipe:
             pipe.multi()
-            pipe.set(f'tardiff:result:{task}', result.to_json_text())
-            pipe.zrem('tardiff:progress', task)
-            if result.status == 'success':
-                pipe.zadd('tardiff:active', {task: datetime.now().timestamp()})
-            pipe.publish("tardiff:complete", b'')
+            pipe.set(f"tardiff:result:{task}", result.to_json_text())
+            pipe.zrem("tardiff:progress", task)
+            if result.status == "success":
+                pipe.zadd("tardiff:active", {task: datetime.now().timestamp()})
+            pipe.publish("tardiff:complete", b"")
             pipe.execute()
 
     def run(self, max_tasks=-1, initial_reconnect_timeout=None):
@@ -184,5 +207,9 @@ class Differ:
 
             return True
 
-        do_pubsub_work(self.redis_client, 'tardiff:queued', do_work,
-                       initial_reconnect_timeout=initial_reconnect_timeout)
+        do_pubsub_work(
+            self.redis_client,
+            "tardiff:queued",
+            do_work,
+            initial_reconnect_timeout=initial_reconnect_timeout,
+        )

--- a/flatpak_indexer/http_utils.py
+++ b/flatpak_indexer/http_utils.py
@@ -1,13 +1,12 @@
-import os
 from typing import Dict
 from urllib.parse import urlparse
+import os
 
 from requests import Session
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util import Retry  # type: ignore
 
-from .base_config import BaseConfig, ConfigError, configfield, Lookup
-
+from .base_config import BaseConfig, ConfigError, Lookup, configfield
 
 _RETRY_MAX_TIMES = 3
 _RETRY_STATUSES = (
@@ -15,7 +14,7 @@ _RETRY_STATUSES = (
     500,  # Internal Server Error
     502,  # Bad Gateway
     503,  # Service Unavailable
-    504   # Gateway Timeout
+    504,  # Gateway Timeout
 )
 
 
@@ -26,7 +25,7 @@ class _FindCACertAdapter(HTTPAdapter):
         self.find_ca_cert = find_ca_cert
 
     def cert_verify(self, conn, url, verify, cert):
-        if url.lower().startswith('https') and verify and self.find_ca_cert:
+        if url.lower().startswith("https") and verify and self.find_ca_cert:
             ca_cert = self.find_ca_cert(url)
             if ca_cert is not None:
                 verify = ca_cert
@@ -49,11 +48,11 @@ class HttpConfig(BaseConfig):
     def __init__(self, lookup: Lookup):
         super().__init__(lookup)
 
-        local_certs = lookup.get_str_dict('local_certs', {})
+        local_certs = lookup.get_str_dict("local_certs", {})
         self.local_certs = {}
         for k, v in local_certs.items():
             if not os.path.isabs(v):
-                cert_dir = os.path.join(os.path.dirname(__file__), 'certs')
+                cert_dir = os.path.join(os.path.dirname(__file__), "certs")
                 v = os.path.join(cert_dir, v)
 
             if not os.path.exists(v):
@@ -87,16 +86,20 @@ class HttpConfig(BaseConfig):
         session = Session()
 
         session.mount(
-            'http://',
-            _FindCACertAdapter(max_retries=retry,
-                               default_timeout=(self.connect_timeout, self.read_timeout),
-                               find_ca_cert=self.find_local_cert)
+            "http://",
+            _FindCACertAdapter(
+                max_retries=retry,
+                default_timeout=(self.connect_timeout, self.read_timeout),
+                find_ca_cert=self.find_local_cert,
+            ),
         )
         session.mount(
-            'https://',
-            _FindCACertAdapter(max_retries=retry,
-                               default_timeout=(self.connect_timeout, self.read_timeout),
-                               find_ca_cert=self.find_local_cert)
+            "https://",
+            _FindCACertAdapter(
+                max_retries=retry,
+                default_timeout=(self.connect_timeout, self.read_timeout),
+                find_ca_cert=self.find_local_cert,
+            ),
         )
 
         return session

--- a/flatpak_indexer/koji_utils.py
+++ b/flatpak_indexer/koji_utils.py
@@ -1,6 +1,5 @@
 import koji
 
-
 from .base_config import BaseConfig
 
 
@@ -11,4 +10,4 @@ class KojiConfig(BaseConfig):
 def get_koji_session(config: KojiConfig):
     options = koji.read_config(profile_name=config.koji_config)
     koji_session_opts = koji.grab_session_options(options)
-    return koji.ClientSession(options['server'], koji_session_opts)
+    return koji.ClientSession(options["server"], koji_session_opts)

--- a/flatpak_indexer/models.py
+++ b/flatpak_indexer/models.py
@@ -95,7 +95,7 @@ class KojiBuildModel(BaseModel):
     def check_json_current(cls, data):
         # For both ImageBuildModule and ModuleBuildModule
         # PackageBuilds changed from <nvr> to { Nvr: <nvr>, SourceNvr: <nvr> }
-        package_builds = data.get('PackageBuilds')
+        package_builds = data.get("PackageBuilds")
         if package_builds:
             if not isinstance(package_builds[0], dict):
                 return False
@@ -108,7 +108,7 @@ class ImageBuildModel(KojiBuildModel):
 
     @classmethod
     def class_from_json(cls, data: Dict[str, Any]):
-        if 'ModuleBuilds' in data:
+        if "ModuleBuilds" in data:
             return FlatpakBuildModel
         else:
             return ImageBuildModel
@@ -191,6 +191,7 @@ class ModuleStreamContentsModel(BaseModel):
 
     def add_package_build(self, image_nvr: str, module_nvr: str, binary_package: BinaryPackage):
         if image_nvr not in self.images:
-            self.images[image_nvr] = ModuleImageContentsModel(image_nvr=image_nvr,
-                                                              module_nvr=module_nvr)
+            self.images[image_nvr] = ModuleImageContentsModel(
+                image_nvr=image_nvr, module_nvr=module_nvr
+            )
         self.images[image_nvr].package_builds.append(binary_package)

--- a/flatpak_indexer/nvr.py
+++ b/flatpak_indexer/nvr.py
@@ -29,7 +29,7 @@ class NVR(str):
 
     @property
     def release(self):
-        return self[self.rfind("-") + 1:]
+        return self[self.rfind("-") + 1 :]
 
     def __lt__(self, other):
         n_a, v_a, r_a = self.rsplit("-", 2)

--- a/flatpak_indexer/redis_utils.py
+++ b/flatpak_indexer/redis_utils.py
@@ -1,7 +1,7 @@
-import logging
-import time
 from typing import Optional
 from urllib.parse import quote, urlparse, urlunparse
+import logging
+import time
 
 import redis
 
@@ -24,12 +24,13 @@ def get_redis_client(config: RedisConfig) -> "redis.Redis[bytes]":
     password = config.redis_password
     if password:
         parts = urlparse(url)
-        netloc = f':{quote(password)}@{parts.hostname}'
+        netloc = f":{quote(password)}@{parts.hostname}"
         if parts.port is not None:
-            netloc += f':{parts.port}'
+            netloc += f":{parts.port}"
 
-        url = urlunparse((parts.scheme, netloc,
-                          parts.path, parts.params, parts.query, parts.fragment))
+        url = urlunparse(
+            (parts.scheme, netloc, parts.path, parts.params, parts.query, parts.fragment)
+        )
 
     return redis.Redis.from_url(url, decode_responses=False)  # type: ignore
 
@@ -59,11 +60,13 @@ def do_pubsub_work(redis_client, topic, callback, initial_reconnect_timeout=None
                 reconnect_timeout = INITIAL_RECONNECT_TIMEOUT
             except redis.ConnectionError:
                 if pubsub and pubsub.connection:
-                    logger.info("Disconnected from Redis, sleeping for %g seconds",
-                                reconnect_timeout)
+                    logger.info(
+                        "Disconnected from Redis, sleeping for %g seconds", reconnect_timeout
+                    )
                 else:
-                    logger.info("Failed to connect to Redis, sleeping for %g seconds",
-                                reconnect_timeout)
+                    logger.info(
+                        "Failed to connect to Redis, sleeping for %g seconds", reconnect_timeout
+                    )
 
                 if pubsub:
                     pubsub.close()

--- a/flatpak_indexer/registry_query.py
+++ b/flatpak_indexer/registry_query.py
@@ -4,17 +4,19 @@ from .models import ImageModel
 from .registry_client import RegistryClient
 from .session import Session
 
-
 # registry-image:<digest> - json representation of the Image
-KEY_PREFIX_REGISTRY_IMAGE = 'registry-image:'
+KEY_PREFIX_REGISTRY_IMAGE = "registry-image:"
 
 logger = logging.getLogger(__name__)
 
 
 def query_registry_image(
-            session: Session, registry_client: RegistryClient, repository_name: str,
-            digest: str, log_as: str
-        ) -> ImageModel:
+    session: Session,
+    registry_client: RegistryClient,
+    repository_name: str,
+    digest: str,
+    log_as: str,
+) -> ImageModel:
     """
     Query an image from a registry with caching in redis
 
@@ -47,7 +49,7 @@ def query_registry_image(
         labels=config["config"]["Labels"],
         annotations={},
         tags=[],
-        diff_ids=config["rootfs"]["diff_ids"]
+        diff_ids=config["rootfs"]["diff_ids"],
     )
 
     session.redis_client.set(KEY_PREFIX_REGISTRY_IMAGE + digest, image.to_json_text())

--- a/flatpak_indexer/session.py
+++ b/flatpak_indexer/session.py
@@ -20,10 +20,12 @@ class Session:
     def build_cache(self):
         # Avoid a circular import
         from flatpak_indexer.build_cache import BuildCache
+
         return BuildCache(self)
 
     @cached_property
     def fedora_releases(self):
         # Avoid a circular import
         from flatpak_indexer.bodhi_query import query_releases
+
         return query_releases(self)

--- a/flatpak_indexer/test/__init__.py
+++ b/flatpak_indexer/test/__init__.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 from typing import Optional
 
-
 rootpath: Optional[Path] = None
 
 

--- a/flatpak_indexer/test/bodhi.py
+++ b/flatpak_indexer/test/bodhi.py
@@ -1,45 +1,44 @@
 from contextlib import contextmanager
 from copy import deepcopy
+from typing import List
+from urllib.parse import parse_qs, urlparse
 import gzip
 import json
 import re
-from typing import List
-from urllib.parse import parse_qs, urlparse
 
 from iso8601 import iso8601
 import responses
 
+from ..bodhi_query import parse_date_value
 from . import get_test_data_path
 from .decorators import WithArgDecorator
-from ..bodhi_query import parse_date_value
-
 
 _updates: List[dict] = []
 
 RELEASES = [
     {
-      "name": "F34",
-      "branch": "f34",
-      "dist_tag": "f34",
-      "state": "archived",
+        "name": "F34",
+        "branch": "f34",
+        "dist_tag": "f34",
+        "state": "archived",
     },
     {
-      "name": "F35",
-      "branch": "f35",
-      "dist_tag": "f35",
-      "state": "current",
+        "name": "F35",
+        "branch": "f35",
+        "dist_tag": "f35",
+        "state": "current",
     },
     {
-      "name": "F36",
-      "branch": "f36",
-      "dist_tag": "f36",
-      "state": "current",
+        "name": "F36",
+        "branch": "f36",
+        "dist_tag": "f36",
+        "state": "current",
     },
     {
-      "name": "F37",
-      "branch": "rawhide",
-      "dist_tag": "f37",
-      "state": "pending",
+        "name": "F37",
+        "branch": "rawhide",
+        "dist_tag": "f37",
+        "state": "pending",
     },
 ]
 
@@ -51,14 +50,14 @@ def load_updates():
 
         data_dir = get_test_data_path() / "updates"
         for child in data_dir.iterdir():
-            if not child.name.endswith('.json.gz'):
+            if not child.name.endswith(".json.gz"):
                 continue
 
-            with gzip.open(child, 'rt') as f:
+            with gzip.open(child, "rt") as f:
                 data = json.load(f)
 
                 # Strip out any builds not in the test data
-                data['builds'] = [x for x in data['builds'] if x['nvr'] in build_nvrs]
+                data["builds"] = [x for x in data["builds"] if x["nvr"] in build_nvrs]
 
                 _updates.append(data)
 
@@ -94,14 +93,14 @@ class MockBodhi:
     def get_updates_callback(self, request):
         params = parse_qs(urlparse(request.url).query)
 
-        page = int(params['page'][0])
-        rows_per_page = int(params['rows_per_page'][0])
-        content_type = params.get('content_type', (None,))[0]
-        packages = params.get('packages')
+        page = int(params["page"][0])
+        rows_per_page = int(params["rows_per_page"][0])
+        content_type = params.get("content_type", (None,))[0]
+        packages = params.get("packages")
 
-        submitted_since = _parse_date_param(params, 'submitted_since')
-        modified_since = _parse_date_param(params, 'modified_since')
-        pushed_since = _parse_date_param(params, 'pushed_since')
+        submitted_since = _parse_date_param(params, "submitted_since")
+        modified_since = _parse_date_param(params, "modified_since")
+        pushed_since = _parse_date_param(params, "pushed_since")
 
         updates = load_updates()
 
@@ -110,22 +109,22 @@ class MockBodhi:
             if self.modify:
                 update = self.modify(update)
 
-            if content_type is not None and update['content_type'] != content_type:
+            if content_type is not None and update["content_type"] != content_type:
                 continue
             if packages is not None:
                 found = False
-                for b in update['builds']:
-                    n, v, r = b['nvr'].rsplit('-', 2)
+                for b in update["builds"]:
+                    n, v, r = b["nvr"].rsplit("-", 2)
                     if n in packages:
                         found = True
                 if not found:
                     continue
 
-            if not _check_date(update, 'date_submitted', submitted_since):
+            if not _check_date(update, "date_submitted", submitted_since):
                 continue
-            if not _check_date(update, 'date_modified', modified_since):
+            if not _check_date(update, "date_modified", modified_since):
                 continue
-            if not _check_date(update, 'date_pushed', pushed_since):
+            if not _check_date(update, "date_pushed", pushed_since):
                 continue
 
             matched_updates.append(update)
@@ -133,66 +132,80 @@ class MockBodhi:
         # The ghost_update flags emulates the problem in
         # https://github.com/fedora-infra/bodhi/issues/4130 where deduplication happens
         # after paging.
-        if 'ghost_updates' in self.flags:
+        if "ghost_updates" in self.flags:
             duplicated_update = matched_updates[rows_per_page - 1]
-            matched_updates[rows_per_page - 1:0] = [duplicated_update] * 3
+            matched_updates[rows_per_page - 1 : 0] = [duplicated_update] * 3
 
         # Sort in descending order by date_submitted
-        matched_updates.sort(key=lambda x: parse_date_value(update['date_submitted']),
-                             reverse=True)
+        matched_updates.sort(key=lambda x: parse_date_value(update["date_submitted"]), reverse=True)
 
         pages = (len(matched_updates) + rows_per_page - 1) // rows_per_page
-        paged_updates = matched_updates[(page - 1) * rows_per_page:page * rows_per_page]
+        paged_updates = matched_updates[(page - 1) * rows_per_page : page * rows_per_page]
 
-        if 'ghost_updates' in self.flags:
+        if "ghost_updates" in self.flags:
             # Deduplicate preserving order
-            paged_updates = list({x['updateid']: x for x in paged_updates}.values())
+            paged_updates = list({x["updateid"]: x for x in paged_updates}.values())
 
         # If something changes during page requests, total could be greater than the
         # number of updates we see
 
         total = len(matched_updates)
-        if 'bad_total' in self.flags:
+        if "bad_total" in self.flags:
             total += 1
 
-        return (200, {}, json.dumps({
-            'page': page,
-            'pages': pages,
-            'rows_per_page': rows_per_page,
-            'total': total,
-            'updates': paged_updates
-        }))
+        return (
+            200,
+            {},
+            json.dumps(
+                {
+                    "page": page,
+                    "pages": pages,
+                    "rows_per_page": rows_per_page,
+                    "total": total,
+                    "updates": paged_updates,
+                }
+            ),
+        )
 
     def get_update_callback(self, request):
         path = urlparse(request.url).path
-        update_id = path.split('/')[-1]
+        update_id = path.split("/")[-1]
 
         updates = load_updates()
         for update in updates:
-            if update['updateid'] == update_id:
+            if update["updateid"] == update_id:
                 if self.modify:
                     update = self.modify(update)
 
-                return (200, {}, json.dumps({
-                    'update': update,
-                    'can_edit': False,
-                }))
+                return (
+                    200,
+                    {},
+                    json.dumps(
+                        {
+                            "update": update,
+                            "can_edit": False,
+                        }
+                    ),
+                )
 
-        return (404, {}, json.dumps({
-            "status": "error",
-            "errors": [
+        return (
+            404,
+            {},
+            json.dumps(
                 {
-                    "location": "url",
-                    "name": "id",
-                    "description": "Invalid update id"
+                    "status": "error",
+                    "errors": [
+                        {"location": "url", "name": "id", "description": "Invalid update id"}
+                    ],
                 }
-            ]}))
+            ),
+        )
 
     def get_releases_callback(self, request):
         params = parse_qs(urlparse(request.url).query)
 
-        page = int(params['page'][0])
-        rows_per_page = int(params['rows_per_page'][0])
+        page = int(params["page"][0])
+        rows_per_page = int(params["rows_per_page"][0])
 
         if self.modify_releases:
             releases = deepcopy(RELEASES)
@@ -201,15 +214,21 @@ class MockBodhi:
             releases = RELEASES
 
         pages = (len(releases) + rows_per_page - 1) // rows_per_page
-        paged_releases = releases[(page - 1) * rows_per_page:page * rows_per_page]
+        paged_releases = releases[(page - 1) * rows_per_page : page * rows_per_page]
 
-        return (200, {}, json.dumps({
-            'page': page,
-            'pages': pages,
-            'rows_per_page': rows_per_page,
-            'total': len(releases),
-            'releases': paged_releases
-        }))
+        return (
+            200,
+            {},
+            json.dumps(
+                {
+                    "page": page,
+                    "pages": pages,
+                    "rows_per_page": rows_per_page,
+                    "total": len(releases),
+                    "releases": paged_releases,
+                }
+            ),
+        )
 
 
 @contextmanager
@@ -217,23 +236,28 @@ def _setup_bodhi(**kwargs):
     with responses._default_mock:
         bodhi_mock = MockBodhi(**kwargs)
 
-        responses.add_callback(method=responses.GET,
-                               url='https://bodhi.fedoraproject.org/updates/',
-                               callback=bodhi_mock.get_updates_callback,
-                               content_type='application/json',
-                               match_querystring=False)
-        responses.add_callback(method=responses.GET,
-                               url=re.compile(
-                                   'https://bodhi.fedoraproject.org/updates/([a-zA-Z0-9-]+)'),
-                               callback=bodhi_mock.get_update_callback,
-                               content_type='application/json',
-                               match_querystring=False)
-        responses.add_callback(method=responses.GET,
-                               url='https://bodhi.fedoraproject.org/releases/',
-                               callback=bodhi_mock.get_releases_callback,
-                               content_type='application/json',
-                               match_querystring=False)
+        responses.add_callback(
+            method=responses.GET,
+            url="https://bodhi.fedoraproject.org/updates/",
+            callback=bodhi_mock.get_updates_callback,
+            content_type="application/json",
+            match_querystring=False,
+        )
+        responses.add_callback(
+            method=responses.GET,
+            url=re.compile("https://bodhi.fedoraproject.org/updates/([a-zA-Z0-9-]+)"),
+            callback=bodhi_mock.get_update_callback,
+            content_type="application/json",
+            match_querystring=False,
+        )
+        responses.add_callback(
+            method=responses.GET,
+            url="https://bodhi.fedoraproject.org/releases/",
+            callback=bodhi_mock.get_releases_callback,
+            content_type="application/json",
+            match_querystring=False,
+        )
         yield bodhi_mock
 
 
-mock_bodhi = WithArgDecorator('bodhi_mock', _setup_bodhi)
+mock_bodhi = WithArgDecorator("bodhi_mock", _setup_bodhi)

--- a/flatpak_indexer/test/decorators.py
+++ b/flatpak_indexer/test/decorators.py
@@ -45,7 +45,7 @@ class WithArgDecorator:
 
             result = partial(wrapper, **{self.arg_name: None})
             update_wrapper(result, wrapper)
-            del result.__dict__['__wrapped__']
+            del result.__dict__["__wrapped__"]
 
             return result
         else:

--- a/flatpak_indexer/test/koji.py
+++ b/flatpak_indexer/test/koji.py
@@ -1,14 +1,13 @@
 from copy import deepcopy
 from functools import wraps
+from typing import Dict, List
+from unittest.mock import DEFAULT, Mock, create_autospec, patch
 import gzip
 import json
-from typing import Dict, List
-from unittest.mock import create_autospec, DEFAULT, Mock, patch
 
 from koji import ClientSession
 
 from . import get_test_data_path
-
 
 _builds: List[dict] = []
 _tags: Dict[str, dict] = {}
@@ -17,9 +16,9 @@ _tags: Dict[str, dict] = {}
 def _load_builds():
     if len(_builds) == 0:
         for child in (get_test_data_path() / "builds").iterdir():
-            if not child.name.endswith('.json.gz'):
+            if not child.name.endswith(".json.gz"):
                 continue
-            with gzip.open(child, 'rt') as f:
+            with gzip.open(child, "rt") as f:
                 _builds.append(json.load(f))
 
     return _builds
@@ -28,16 +27,16 @@ def _load_builds():
 def _load_tags():
     if len(_tags) == 0:
         for child in (get_test_data_path() / "tags").iterdir():
-            if not child.name.endswith('.json.gz'):
+            if not child.name.endswith(".json.gz"):
                 continue
             tag = child.name[:-8]
-            with gzip.open(child, 'rt') as f:
+            with gzip.open(child, "rt") as f:
                 _tags[tag] = json.load(f)
 
     return _tags
 
 
-class MockKojiContext():
+class MockKojiContext:
     def __init__(self, filter_archives=None, filter_build=None, tag_query_timestamp=None):
         self.filter_archives = filter_archives
         self.filter_build = filter_build
@@ -46,39 +45,39 @@ class MockKojiContext():
     def get_build(self, nvr):
         if isinstance(nvr, int):
             for b in _load_builds():
-                if b['id'] == nvr:
+                if b["id"] == nvr:
                     return b
         else:
             for b in _load_builds():
-                if b['nvr'] == nvr:
+                if b["nvr"] == nvr:
                     return b
 
         return None
 
     def get_package_id(self, name):
         return {
-            'baobab': 1369,
-            'bubblewrap': 22617,
-            'django': 26201,
-            'eog': 303,
-            'exempi': 4845,
-            'feedreader': 20956,
-            'flatpak-rpm-macros': 24301,
-            'flatpak-common': 27629,
-            'flatpak-runtime': 25428,
-            'gnome-clocks': 14779,
-            'gnome-desktop3': 10518,
-            'gnome-weather': 15839,
-            'libpeas': 10531,
-            'quadrapassel': 16135,
+            "baobab": 1369,
+            "bubblewrap": 22617,
+            "django": 26201,
+            "eog": 303,
+            "exempi": 4845,
+            "feedreader": 20956,
+            "flatpak-rpm-macros": 24301,
+            "flatpak-common": 27629,
+            "flatpak-runtime": 25428,
+            "gnome-clocks": 14779,
+            "gnome-desktop3": 10518,
+            "gnome-weather": 15839,
+            "libpeas": 10531,
+            "quadrapassel": 16135,
         }.get(name)
 
     def list_archives(self, build_id):
         for b in _load_builds():
-            if b['id'] == build_id:
-                archives = deepcopy(b['archives'])
+            if b["id"] == build_id:
+                archives = deepcopy(b["archives"])
                 for a in archives:
-                    del a['components']
+                    del a["components"]
 
                 if self.filter_archives:
                     archives = self.filter_archives(b, archives)
@@ -94,38 +93,38 @@ class MockKojiContext():
                 if b is None:
                     continue
 
-            extra = b.get('extra')
+            extra = b.get("extra")
             if extra:
-                typeinfo = extra.get('typeinfo')
+                typeinfo = extra.get("typeinfo")
             else:
                 typeinfo = None
 
-            if extra and extra.get('image'):
-                btype = 'image'
-            elif typeinfo and typeinfo.get('module'):
-                btype = 'module'
+            if extra and extra.get("image"):
+                btype = "image"
+            elif typeinfo and typeinfo.get("module"):
+                btype = "module"
             else:
-                btype = 'rpm'
+                btype = "rpm"
 
             if type is not None and btype != type:
                 continue
-            if packageID is not None and b['package_id'] != packageID:
+            if packageID is not None and b["package_id"] != packageID:
                 continue
-            if state is not None and b['state'] != state:
+            if state is not None and b["state"] != state:
                 continue
 
-            if completeAfter is not None and b['completion_ts'] <= completeAfter:
+            if completeAfter is not None and b["completion_ts"] <= completeAfter:
                 continue
 
             b2 = deepcopy(b)
-            if 'archives' in b:
-                del b2['archives']
+            if "archives" in b:
+                del b2["archives"]
 
             result.append(b)
 
         # Descending order by build_id seems to match what koji does, in any case
         # we don't want to order in readdir order
-        result.sort(key=lambda x: x['build_id'], reverse=True)
+        result.sort(key=lambda x: x["build_id"], reverse=True)
 
         return result
 
@@ -134,40 +133,43 @@ class MockKojiContext():
             raise RuntimeError("listRPMs - only lookup by imageID is implemented")
 
         for b in _load_builds():
-            if 'archives' not in b:
+            if "archives" not in b:
                 continue
-            for archive in b['archives']:
-                if archive['id'] == imageID:
-                    return archive['components']
+            for archive in b["archives"]:
+                if archive["id"] == imageID:
+                    return archive["components"]
 
         raise RuntimeError(f"Image id={imageID} not found")
 
     def query_history(self, tables=None, tag=None, afterEvent=None):
-        assert tables == ['tag_listing']
+        assert tables == ["tag_listing"]
         assert tag is not None
 
         result = []
         tags = _load_tags()
         for item in tags.get(tag, ()):
             if self.tag_query_timestamp:
-                if item['create_ts'] > self.tag_query_timestamp:
+                if item["create_ts"] > self.tag_query_timestamp:
                     continue
 
-                if item['revoke_ts'] is not None and item['revoke_ts'] > self.tag_query_timestamp:
+                if item["revoke_ts"] is not None and item["revoke_ts"] > self.tag_query_timestamp:
                     item = item.copy()
-                    item['revoke_ts'] = None
-                    item['revoke_event'] = None
-                    item['revoker_id'] = None
-                    item['rovoker_name'] = None
+                    item["revoke_ts"] = None
+                    item["revoke_event"] = None
+                    item["revoker_id"] = None
+                    item["rovoker_name"] = None
 
             if afterEvent:
-                if not (item['create_event'] > afterEvent or
-                        item['revoke_event'] and item['revoke_event'] > afterEvent):
+                if not (
+                    item["create_event"] > afterEvent
+                    or item["revoke_event"]
+                    and item["revoke_event"] > afterEvent
+                ):
                     continue
 
             result.append(item)
 
-        return {'tag_listing': result}
+        return {"tag_listing": result}
 
 
 def make_koji_session(**kwargs):
@@ -195,11 +197,10 @@ def mock_koji(f):
 
     @wraps(f)
     def wrapper(*args, **kwargs):
-        with patch.multiple('koji',
-                            read_config=DEFAULT,
-                            grab_session_options=DEFAULT,
-                            ClientSession=DEFAULT) as mocks:
-            mocks['ClientSession'].return_value = session
+        with patch.multiple(
+            "koji", read_config=DEFAULT, grab_session_options=DEFAULT, ClientSession=DEFAULT
+        ) as mocks:
+            mocks["ClientSession"].return_value = session
 
             return f(*args, **kwargs)
 

--- a/flatpak_indexer/test/redis.py
+++ b/flatpak_indexer/test/redis.py
@@ -24,7 +24,7 @@ def mock_redis(f=None, expect_url=None):
 
             return fakeredis.FakeStrictRedis(server=server)  # type: ignore
 
-        with patch('redis.Redis.from_url', side_effect=from_url):
+        with patch("redis.Redis.from_url", side_effect=from_url):
             return f(*args, **kwargs)
 
     return wrapper

--- a/flatpak_indexer/utils.py
+++ b/flatpak_indexer/utils.py
@@ -1,18 +1,17 @@
-import codecs
 from collections import namedtuple
 from contextlib import contextmanager
 from datetime import datetime, timezone
+from shutil import rmtree
+from tempfile import NamedTemporaryFile, mkdtemp
+from typing import IO, Tuple, cast
+from urllib.parse import urljoin
+import codecs
 import hashlib
 import logging
 import os
 import re
-from shutil import rmtree
 import subprocess
-from tempfile import mkdtemp, NamedTemporaryFile
 import typing
-from typing import cast, IO, Tuple
-from urllib.parse import urljoin
-
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +35,7 @@ def _substitute_env_vars(itr, outer=True):
             m = next(itr, None)
             if m is None:
                 raise SubstitutionError("unclosed variable reference")
-            elif m.group('varname'):
+            elif m.group("varname"):
                 varname = m.group(0)
                 m = next(itr, None)
                 if m is None:
@@ -49,13 +48,16 @@ def _substitute_env_vars(itr, outer=True):
                         result += os.environ[varname]
                     except KeyError:
                         raise SubstitutionError(
-                            "environment variable {} is not set".format(varname)) from None
+                            "environment variable {} is not set".format(varname)
+                        ) from None
                 else:
                     raise SubstitutionError(
-                        "at position {} in field: expected : or }}".format(m.start()))
+                        "at position {} in field: expected : or }}".format(m.start())
+                    )
             else:
                 raise SubstitutionError(
-                    "at position {} in field: expected variable name".format(m.start()))
+                    "at position {} in field: expected variable name".format(m.start())
+                )
         elif m.group(0) == "}" and not outer:
             return result
         else:
@@ -65,9 +67,7 @@ def _substitute_env_vars(itr, outer=True):
 @contextmanager
 def atomic_writer(output_path):
     output_dir = os.path.dirname(output_path)
-    tmpfile = NamedTemporaryFile(delete=False,
-                                 dir=output_dir,
-                                 prefix=os.path.basename(output_path))
+    tmpfile = NamedTemporaryFile(delete=False, dir=output_dir, prefix=os.path.basename(output_path))
     success = False
     try:
         writer = cast(IO[str], codecs.getwriter("utf-8")(tmpfile))
@@ -120,8 +120,7 @@ def pseudo_atomic_dir_writer(path: str):
     success = False
     tempdir = None
     try:
-        tempdir = mkdtemp(prefix=os.path.basename(path) + '.',
-                          dir=os.path.dirname(path))
+        tempdir = mkdtemp(prefix=os.path.basename(path) + ".", dir=os.path.dirname(path))
         yield tempdir
         success = True
     finally:
@@ -139,10 +138,7 @@ def pseudo_atomic_dir_writer(path: str):
 
 class TemporaryPathname:
     def __init__(self, suffix=None, prefix=None, dir=None):
-        tmpfile = NamedTemporaryFile(delete=False,
-                                     dir=dir,
-                                     prefix=prefix,
-                                     suffix=suffix)
+        tmpfile = NamedTemporaryFile(delete=False, dir=dir, prefix=prefix, suffix=suffix)
         tmpfile.close()
 
         self.name = tmpfile.name
@@ -166,7 +162,7 @@ def format_date(dt):
     Naive (no-timezone) dates are interpreted as the local timezone
     """
     utc_dt = dt.astimezone(timezone.utc)
-    return utc_dt.strftime('%Y-%m-%dT%H:%M:%S.%f+00:00')
+    return utc_dt.strftime("%Y-%m-%dT%H:%M:%S.%f+00:00")
 
 
 def parse_date(date_str):
@@ -176,9 +172,9 @@ def parse_date(date_str):
     storing dates into JSON ourselves.
     """
     try:
-        dt = datetime.strptime(date_str, '%Y-%m-%dT%H:%M:%S.%f+00:00')
+        dt = datetime.strptime(date_str, "%Y-%m-%dT%H:%M:%S.%f+00:00")
     except ValueError:
-        dt = datetime.strptime(date_str, '%Y-%m-%dT%H:%M:%S+00:00')
+        dt = datetime.strptime(date_str, "%Y-%m-%dT%H:%M:%S+00:00")
 
     return dt.replace(tzinfo=timezone.utc)
 
@@ -186,32 +182,32 @@ def parse_date(date_str):
 def parse_pull_spec(spec):
     """Parse <registry>[:port]/<repository>[@<digest>|:tag]"""
 
-    server_port, repository_ref = spec.split('/', 1)
-    if '@' in repository_ref:
-        repository, ref = repository_ref.rsplit('@', 1)
+    server_port, repository_ref = spec.split("/", 1)
+    if "@" in repository_ref:
+        repository, ref = repository_ref.rsplit("@", 1)
     else:
-        repository, ref = repository_ref.rsplit(':', 1)
+        repository, ref = repository_ref.rsplit(":", 1)
 
-    return 'https://' + server_port, repository, ref
+    return "https://" + server_port, repository, ref
 
 
 def unparse_pull_spec(registry_url, repository, ref):
-    assert registry_url.startswith('https://')
+    assert registry_url.startswith("https://")
     server_port = registry_url[8:]
-    if not server_port.endswith('/'):
-        server_port += '/'
+    if not server_port.endswith("/"):
+        server_port += "/"
 
-    if ref.startswith('sha256:'):
-        return f'{server_port}{repository}@{ref}'
+    if ref.startswith("sha256:"):
+        return f"{server_port}{repository}@{ref}"
     else:
-        return f'{server_port}{repository}:{ref}'
+        return f"{server_port}{repository}:{ref}"
 
 
 def uri_for_digest(base_uri: str, digest: str, extension: str):
     assert digest.startswith("sha256:")
     subdir = digest[7:9]
     filename = digest[9:] + extension
-    return urljoin(base_uri, subdir + '/' + filename)
+    return urljoin(base_uri, subdir + "/" + filename)
 
 
 def path_for_digest(base_dir, digest, extension, create_subdir=False):
@@ -227,16 +223,14 @@ def path_for_digest(base_dir, digest, extension, create_subdir=False):
     return os.path.join(base_dir, subdir, filename)
 
 
-ProcessStats = namedtuple('ProcessStats',
-                          ['max_mem_kib',
-                           'elapsed_time_s',
-                           'system_time_s',
-                           'user_time_s'])
+ProcessStats = namedtuple(
+    "ProcessStats", ["max_mem_kib", "elapsed_time_s", "system_time_s", "user_time_s"]
+)
 
 
 def run_with_stats(args, progress_callback=None):
     with TemporaryPathname() as time_file:
-        time_args = ['time', '-q', '--format=%M %e %S %U', f'--output={time_file.name}'] + args
+        time_args = ["time", "-q", "--format=%M %e %S %U", f"--output={time_file.name}"] + args
         p = subprocess.Popen(time_args)
 
         while True:
@@ -251,13 +245,14 @@ def run_with_stats(args, progress_callback=None):
 
         with open(time_file.name, "r") as f:
             y = f.read()
-            max_mem, elapsed_time, system_time, user_time = \
-                [x for x in y.strip().split()]
+            max_mem, elapsed_time, system_time, user_time = [x for x in y.strip().split()]
 
-            stats = ProcessStats(max_mem_kib=float(max_mem),
-                                 elapsed_time_s=float(elapsed_time),
-                                 system_time_s=float(system_time),
-                                 user_time_s=float(user_time))
+            stats = ProcessStats(
+                max_mem_kib=float(max_mem),
+                elapsed_time_s=float(elapsed_time),
+                system_time_s=float(system_time),
+                user_time_s=float(user_time),
+            )
 
         return result, stats
 
@@ -266,14 +261,15 @@ def resolve_type(type_) -> Tuple[type, Tuple, bool]:
     # could use typing_inspect PyPI module; this hack is especially ugly
     # since the string representation changed from python-3.8 to python-3.9
     type_str = str(type_)
-    if (type_str.startswith('typing.Optional[') or
-            (type_str.startswith('typing.Union[') and type_str.endswith(', NoneType]'))):
+    if type_str.startswith("typing.Optional[") or (
+        type_str.startswith("typing.Union[") and type_str.endswith(", NoneType]")
+    ):
         type_ = typing.get_args(type_)[0]
         optional = True
     else:
         optional = False
 
-    origin = getattr(type_, '__origin__', None)
+    origin = getattr(type_, "__origin__", None)
     if origin is None:
         return type_, (), optional
     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,14 +24,12 @@ dependencies = [
     # 2.22.0 contains an accidental incompatibility with python < 3.11,
     # fixed in git.
     "fakeredis!=2.22.0",
-    "flake8",
-    "flake8-import-order",
-    "flake8-pyproject>=0.9.1",
     "graphql-core",
     "iso8601",
     "pytest",
     "pytest-cov",
     "pytest-socket",
+    "ruff",
     "responses",
     "www-authenticate",
 ]
@@ -43,9 +41,6 @@ flatpak-indexer = "flatpak_indexer.cli:cli"
 # Alternative: install only dev dependencies separately
 dev = [
     "fakeredis!=2.22.0",
-    "flake8",
-    "flake8-import-order",
-    "flake8-pyproject>=0.9.1",
     "graphql-core",
     "iso8601",
     "pytest",
@@ -75,10 +70,14 @@ exclude_lines = [
 ]
 omit = ["flatpak_indexer/test/*"]
 
-[tool.flake8]
-application_import_names = ["flatpak_indexer"]
-import_order_style = "google"
-max_line_length = 100
+[tool.ruff]
+line-length = 100
+
+[tool.ruff.lint]
+extend-select = ["I"]
+
+[tool.ruff.lint.isort]
+from-first = true
 
 [tool.pytest]
 addopts = [

--- a/tests/pyxis.py
+++ b/tests/pyxis.py
@@ -1,10 +1,10 @@
 from contextlib import contextmanager
-import copy
 from dataclasses import dataclass
 from datetime import datetime
+from typing import List, Optional
+import copy
 import json
 import re
-from typing import List, Optional
 
 import graphql
 import responses
@@ -59,154 +59,136 @@ class GetImagesForRepository:
 
 
 _REPOSITORIES = [
-    Repository(registry='registry2.example.com',
-               repository='testrepo',
-               build_categories=['Standalone Image']),
-    Repository(registry='registry.example.com',
-               repository='testrepo',
-               build_categories=['Standalone Image']),
-    Repository(registry='registry.example.com',
-               repository='el8/aisleriot',
-               build_categories=['Flatpak']),
-    Repository(registry='registry.example.com',
-               repository='el9/aisleriot',
-               build_categories=['Flatpak']),
-    Repository(registry='registry.example.com',
-               repository='aisleriot2',
-               build_categories=['Flatpak']),
-    Repository(registry='registry.example.com',
-               repository='aisleriot3',
-               build_categories=['Flatpak']),
+    Repository(
+        registry="registry2.example.com",
+        repository="testrepo",
+        build_categories=["Standalone Image"],
+    ),
+    Repository(
+        registry="registry.example.com",
+        repository="testrepo",
+        build_categories=["Standalone Image"],
+    ),
+    Repository(
+        registry="registry.example.com", repository="el8/aisleriot", build_categories=["Flatpak"]
+    ),
+    Repository(
+        registry="registry.example.com", repository="el9/aisleriot", build_categories=["Flatpak"]
+    ),
+    Repository(
+        registry="registry.example.com", repository="aisleriot2", build_categories=["Flatpak"]
+    ),
+    Repository(
+        registry="registry.example.com", repository="aisleriot3", build_categories=["Flatpak"]
+    ),
 ]
 
 
 _REPO_IMAGES = [
     ContainerImage(
-        architecture='amd64',
-        brew=Brew(
-            build='testrepo-container-1.2.3-1'
-        ),
-        image_id='sha256:babb1ed1c4d226da18ec4a6386263d8b2125fc874c8b4f4f97b31593037ea0bb',
+        architecture="amd64",
+        brew=Brew(build="testrepo-container-1.2.3-1"),
+        image_id="sha256:babb1ed1c4d226da18ec4a6386263d8b2125fc874c8b4f4f97b31593037ea0bb",
         repositories=[
             ContainerImageRepo(
-                registry='registry2.example.com',
-                repository='testrepo',
-                push_date='2019-04-25T18:50:02.708000+00:00',
-                tags=[]
+                registry="registry2.example.com",
+                repository="testrepo",
+                push_date="2019-04-25T18:50:02.708000+00:00",
+                tags=[],
             ),
             ContainerImageRepo(
-                registry='registry.example.com',
-                repository='testrepo',
-                push_date='2019-04-25T18:50:02.708000+00:00',
-                tags=[
-                    ContainerImageRepoTag(name='latest')
-                ]
+                registry="registry.example.com",
+                repository="testrepo",
+                push_date="2019-04-25T18:50:02.708000+00:00",
+                tags=[ContainerImageRepoTag(name="latest")],
             ),
-        ]
+        ],
     ),
     ContainerImage(
-        architecture='amd64',
-        brew=Brew(
-            build='aisleriot-container-el8-8020020200121102609.1'
-        ),
-        image_id='sha256:bo1dfacec4d226da18ec4a6386263d8b2125fc874c8b4f4f97b31593037ea0bb',
+        architecture="amd64",
+        brew=Brew(build="aisleriot-container-el8-8020020200121102609.1"),
+        image_id="sha256:bo1dfacec4d226da18ec4a6386263d8b2125fc874c8b4f4f97b31593037ea0bb",
         repositories=[
             ContainerImageRepo(
-                registry='registry.example.com',
-                repository='el8/aisleriot',
-                push_date='2019-04-25T18:50:02.708000+00:00',
-                tags=[
-                    ContainerImageRepoTag(name='latest'),
-                    ContainerImageRepoTag(name='rhel8')
-                ]
+                registry="registry.example.com",
+                repository="el8/aisleriot",
+                push_date="2019-04-25T18:50:02.708000+00:00",
+                tags=[ContainerImageRepoTag(name="latest"), ContainerImageRepoTag(name="rhel8")],
             )
-        ]
+        ],
     ),
     ContainerImage(
-        architecture='amd64',
-        brew=Brew(
-            build='aisleriot-container-el9-9010020220121102609.1'
-        ),
-        image_id='sha256:ba5eba11c4d226da18ec4a6386263d8b2125fc874c8b4f4f97b31593037ea0bb',
+        architecture="amd64",
+        brew=Brew(build="aisleriot-container-el9-9010020220121102609.1"),
+        image_id="sha256:ba5eba11c4d226da18ec4a6386263d8b2125fc874c8b4f4f97b31593037ea0bb",
         repositories=[
             ContainerImageRepo(
-                registry='registry.example.com',
-                repository='el9/aisleriot',
-                push_date='2019-04-25T18:50:02.708000+00:00',
-                tags=[
-                    ContainerImageRepoTag(name='latest')
-                ]
+                registry="registry.example.com",
+                repository="el9/aisleriot",
+                push_date="2019-04-25T18:50:02.708000+00:00",
+                tags=[ContainerImageRepoTag(name="latest")],
             )
-        ]
+        ],
     ),
     ContainerImage(
-        architecture='amd64',
-        brew=Brew(
-            build='aisleriot-container-el9-9010020220121102609.2'
-        ),
-        image_id='sha256:AISLERIOT_EL9_2_MANIFEST_DIGEST',
+        architecture="amd64",
+        brew=Brew(build="aisleriot-container-el9-9010020220121102609.2"),
+        image_id="sha256:AISLERIOT_EL9_2_MANIFEST_DIGEST",
         repositories=[
             ContainerImageRepo(
-                registry='registry.example.com',
-                repository='el9/aisleriot',
-                push_date='2019-04-25T18:50:02.708000+00:00',
-                tags=None
+                registry="registry.example.com",
+                repository="el9/aisleriot",
+                push_date="2019-04-25T18:50:02.708000+00:00",
+                tags=None,
             )
-        ]
+        ],
     ),
     ContainerImage(
-        architecture='amd64',
+        architecture="amd64",
         brew=Brew(
-            build='aisleriot2-container-el8-8020020200121102609.1',
+            build="aisleriot2-container-el8-8020020200121102609.1",
         ),
-        image_id='sha256:5eaf00d1c4d226da18ec4a6386263d8b2125fc874c8b4f4f97b31593037ea0bb',
+        image_id="sha256:5eaf00d1c4d226da18ec4a6386263d8b2125fc874c8b4f4f97b31593037ea0bb",
         repositories=[
             ContainerImageRepo(
-                registry='registry.example.com',
-                repository='aisleriot2',
-                push_date='2019-04-25T18:50:02.708000+00:00',
-                tags=[
-                    ContainerImageRepoTag(name='latest'),
-                    ContainerImageRepoTag(name='rhel8')
-                ]
+                registry="registry.example.com",
+                repository="aisleriot2",
+                push_date="2019-04-25T18:50:02.708000+00:00",
+                tags=[ContainerImageRepoTag(name="latest"), ContainerImageRepoTag(name="rhel8")],
             )
-        ]
+        ],
     ),
     ContainerImage(
-        architecture='ppc64le',
+        architecture="ppc64le",
         brew=Brew(
-            build='testrepo-container-1.2.3-1',
+            build="testrepo-container-1.2.3-1",
         ),
-        image_id='sha256:fl055ed1c4d226da18ec4a6386263d8b2125fc874c8b4f4f97b31593037ea0bb',
+        image_id="sha256:fl055ed1c4d226da18ec4a6386263d8b2125fc874c8b4f4f97b31593037ea0bb",
         repositories=[
             ContainerImageRepo(
-                registry='registry.example.com',
-                repository='testrepo',
-                push_date='2019-04-25T18:50:02.708000+00:00',
-                tags=[
-                    ContainerImageRepoTag(name='latest')
-                ]
+                registry="registry.example.com",
+                repository="testrepo",
+                push_date="2019-04-25T18:50:02.708000+00:00",
+                tags=[ContainerImageRepoTag(name="latest")],
             )
-        ]
-    )
+        ],
+    ),
 ]
 
 
 _NEWER_UNTAGGED_IMAGE = ContainerImage(
-        architecture='amd64',
-        brew=Brew(
-            build='aisleriot-container-el8-8020020200121102609.42'
-        ),
-        image_id='sha256:bo1dfacec4d226da18ec4a6386263d8b2125fc874c8b4f4f97b31593037ea0bb',
-        repositories=[
-            ContainerImageRepo(
-                registry='registry.example.com',
-                repository='el8/aisleriot',
-                push_date='2024-04-25T18:50:02.708000+00:00',
-                tags=[]
-            )
-        ]
-    )
+    architecture="amd64",
+    brew=Brew(build="aisleriot-container-el8-8020020200121102609.42"),
+    image_id="sha256:bo1dfacec4d226da18ec4a6386263d8b2125fc874c8b4f4f97b31593037ea0bb",
+    repositories=[
+        ContainerImageRepo(
+            registry="registry.example.com",
+            repository="el8/aisleriot",
+            push_date="2024-04-25T18:50:02.708000+00:00",
+            tags=[],
+        )
+    ],
+)
 
 
 schema = graphql.utilities.build_schema("""
@@ -287,7 +269,7 @@ class User:
 
 
 def paginate(results, page, page_size):
-    return results[page * page_size:page * page_size + page_size]
+    return results[page * page_size : page * page_size + page_size]
 
 
 class MockPyxis:
@@ -298,7 +280,7 @@ class MockPyxis:
         if bad_digests:
             self.repo_images = copy.deepcopy(self.repo_images)
             for ci in self.repo_images:
-                ci.image_id = 'sha256:deadbeef'
+                ci.image_id = "sha256:deadbeef"
 
         if newer_untagged_image:
             self.repo_images = copy.copy(self.repo_images)
@@ -311,75 +293,65 @@ class MockPyxis:
 
     def graphql(self, request):
         parsed = json.loads(request.body)
-        result = graphql.graphql_sync(schema, parsed["query"], self,
-                                      variable_values=parsed["variables"])
+        result = graphql.graphql_sync(
+            schema, parsed["query"], self, variable_values=parsed["variables"]
+        )
         if result.errors:
-            return (400, {}, json.dumps({
-                'errors': [
+            return (
+                400,
+                {},
+                json.dumps(
                     {
-                        'message': e.message,
-                        'locations': [
+                        "errors": [
                             {
-                                "line": loc.line,
-                                "column": loc.column,
+                                "message": e.message,
+                                "locations": [
+                                    {
+                                        "line": loc.line,
+                                        "column": loc.column,
+                                    }
+                                    for loc in e.locations or []
+                                ],
                             }
-                            for loc in e.locations or []
+                            for e in result.errors
                         ]
-                    } for e in result.errors
-                ]
-            }))
+                    }
+                ),
+            )
         else:
-            return (200, {}, json.dumps({
-                'data': result.data
-            }))
+            return (200, {}, json.dumps({"data": result.data}))
 
     def find_repositories(self, info, page: int = 0, page_size: int = 50, filter=None):
         EXPECTED_FILTER = {
             "and": [
-                {
-                    "or": [
-                        {
-                            "eol_date": {
-                                "eq": None
-                            }
-                        },
-                        {
-                            "eol_date": {
-                                "gt": "DATE"
-                            }
-                        }
-                    ]
-                },
-                {
-                    "build_categories": {
-                        "in": [
-                            "Flatpak"
-                        ]
-                    }
-                }
+                {"or": [{"eol_date": {"eq": None}}, {"eol_date": {"gt": "DATE"}}]},
+                {"build_categories": {"in": ["Flatpak"]}},
             ]
         }
-        expected_filter_regexp = re.escape(json.dumps(EXPECTED_FILTER)).replace("DATE", "([^\"]+)")
+        expected_filter_regexp = re.escape(json.dumps(EXPECTED_FILTER)).replace("DATE", '([^"]+)')
 
         if filter is not None:
             m = re.match(expected_filter_regexp, json.dumps(filter))
             assert m
             eol_date = datetime.fromisoformat(m.group(1))
             data = [
-                r for r in self.repositories
-                if (r.eol_date is None or r.eol_date > eol_date)
-                and "Flatpak" in r.build_categories
+                r
+                for r in self.repositories
+                if (r.eol_date is None or r.eol_date > eol_date) and "Flatpak" in r.build_categories
             ]
         else:
             data = self.repositories
 
         return GetRepositories(data=paginate(data, page, page_size), total=len(data))
 
-    def find_repository_images_by_registry_path(self, info, registry: str, repository: str,
-                                                page: int = 0, page_size: int = 50):
-        data = [ci for ci in self.repo_images
-                if any(r.registry == registry and r.repository == repository
-                       for r in ci.repositories)]
+    def find_repository_images_by_registry_path(
+        self, info, registry: str, repository: str, page: int = 0, page_size: int = 50
+    ):
+        data = [
+            ci
+            for ci in self.repo_images
+            if any(r.registry == registry and r.repository == repository for r in ci.repositories)
+        ]
 
         return GetImagesForRepository(data=paginate(data, page, page_size), total=len(data))
 
@@ -389,12 +361,14 @@ def _setup_pyxis(**kwargs):
     with responses._default_mock:
         pyxis_mock = MockPyxis(**kwargs)
 
-        responses.add_callback(responses.POST,
-                               "https://pyxis.example.com/graphql/",
-                               callback=pyxis_mock.graphql,
-                               content_type='application/json')
+        responses.add_callback(
+            responses.POST,
+            "https://pyxis.example.com/graphql/",
+            callback=pyxis_mock.graphql,
+            content_type="application/json",
+        )
 
         yield pyxis_mock
 
 
-mock_pyxis = WithArgDecorator('pyxis_mock', _setup_pyxis)
+mock_pyxis = WithArgDecorator("pyxis_mock", _setup_pyxis)

--- a/tests/test_bodhi_query.py
+++ b/tests/test_bodhi_query.py
@@ -1,13 +1,17 @@
-import copy
 from datetime import datetime
-import logging
 from textwrap import dedent
+import copy
+import logging
 
 import pytest
 
 from flatpak_indexer.bodhi_query import (
-    list_updates, query_releases,
-    refresh_all_updates, refresh_update_status, refresh_updates, reset_update_cache
+    list_updates,
+    query_releases,
+    refresh_all_updates,
+    refresh_update_status,
+    refresh_updates,
+    reset_update_cache,
 )
 from flatpak_indexer.http_utils import HttpConfig
 from flatpak_indexer.koji_utils import KojiConfig
@@ -26,10 +30,12 @@ class TestConfig(HttpConfig, KojiConfig, RedisConfig):
 
 @pytest.fixture
 def session():
-    config = TestConfig.from_str(dedent("""
+    config = TestConfig.from_str(
+        dedent("""
         koji_config: fedora
         redis_url: redis://localhost
-"""))
+""")
+    )
     return Session(config)
 
 
@@ -37,23 +43,23 @@ def session():
 @mock_redis
 @mock_bodhi
 def test_bodhi_query_package_updates(session):
-    refresh_updates(session, 'rpm', entities=['libpeas'])
+    refresh_updates(session, "rpm", entities=["libpeas"])
 
-    updates = list_updates(session, 'rpm', 'libpeas')
+    updates = list_updates(session, "rpm", "libpeas")
     assert len(updates) == 4
 
-    update = [x for x in updates if 'libpeas-1.30.0-4.fc35' in x.builds][0]
+    update = [x for x in updates if "libpeas-1.30.0-4.fc35" in x.builds][0]
 
-    assert update.user_name == 'hadess'
-    assert update.date_submitted.strftime("%Y-%m-%d %H:%M:%S") == '2021-06-14 08:37:11'
+    assert update.user_name == "hadess"
+    assert update.date_submitted.strftime("%Y-%m-%d %H:%M:%S") == "2021-06-14 08:37:11"
     assert update.date_testing is not None
-    assert update.date_testing.strftime("%Y-%m-%d %H:%M:%S") == '2021-06-14 08:37:32'
+    assert update.date_testing.strftime("%Y-%m-%d %H:%M:%S") == "2021-06-14 08:37:32"
     assert update.date_stable is not None
-    assert update.date_stable.strftime("%Y-%m-%d %H:%M:%S") == '2021-06-14 08:38:35'
+    assert update.date_stable.strftime("%Y-%m-%d %H:%M:%S") == "2021-06-14 08:38:35"
 
-    assert update.builds == ['libpeas-1.30.0-4.fc35']
-    assert update.status == 'stable'
-    assert update.type == 'unspecified'
+    assert update.builds == ["libpeas-1.30.0-4.fc35"]
+    assert update.status == "stable"
+    assert update.type == "unspecified"
 
 
 @mock_koji
@@ -63,14 +69,14 @@ def test_bodhi_query_package_updates_many(session):
     # gnome-weather picks up multi-package updates
     # eog picks up Flatpak updates
     #   (since we don't specify content_type=rpm to avoid pessimizing a bodhi query)
-    entities = [str(n) + 'libpeas' for n in range(0, 9)] + ['pango', 'libpeas', 'eog']
+    entities = [str(n) + "libpeas" for n in range(0, 9)] + ["pango", "libpeas", "eog"]
 
-    refresh_updates(session, 'rpm', entities, rows_per_page=1)
+    refresh_updates(session, "rpm", entities, rows_per_page=1)
 
-    updates = list_updates(session, 'rpm', 'libpeas')
+    updates = list_updates(session, "rpm", "libpeas")
     assert len(updates) == 4
 
-    updates = list_updates(session, 'rpm', 'gnome-weather')
+    updates = list_updates(session, "rpm", "gnome-weather")
     assert len(updates) == 4
 
 
@@ -79,30 +85,31 @@ def test_bodhi_query_package_updates_many(session):
 @mock_bodhi
 def test_bodhi_query_update_changed(bodhi_mock, session):
     def modify_update(update):
-        if update['updateid'] == 'FEDORA-2021-511edcde29':
+        if update["updateid"] == "FEDORA-2021-511edcde29":
             update_copy = copy.deepcopy(update)
 
-            update_copy['builds'] = [b for b in update_copy['builds']
-                                     if not b['nvr'].startswith('sushi-')]
-            update_copy['date_modified'] = datetime.utcnow().strftime('%Y-%m-%d %H:%M:%S')
+            update_copy["builds"] = [
+                b for b in update_copy["builds"] if not b["nvr"].startswith("sushi-")
+            ]
+            update_copy["date_modified"] = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
 
             return update_copy
         else:
             return update
 
-    refresh_updates(session, 'rpm', ['gnome-weather', 'bijiben'])
+    refresh_updates(session, "rpm", ["gnome-weather", "bijiben"])
 
-    updates = list_updates(session, 'rpm', 'gnome-weather')
+    updates = list_updates(session, "rpm", "gnome-weather")
     assert len(updates) == 4
-    updates = list_updates(session, 'rpm', 'sushi')
+    updates = list_updates(session, "rpm", "sushi")
     assert len(updates) == 1
 
     bodhi_mock.modify = modify_update
-    refresh_updates(session, 'rpm', ['gnome-weather', 'sushi'])
+    refresh_updates(session, "rpm", ["gnome-weather", "sushi"])
 
-    updates = list_updates(session, 'rpm', 'gnome-weather')
+    updates = list_updates(session, "rpm", "gnome-weather")
     assert len(updates) == 4
-    updates = list_updates(session, 'rpm', 'sushi')
+    updates = list_updates(session, "rpm", "sushi")
     assert len(updates) == 0
 
 
@@ -110,71 +117,74 @@ def test_bodhi_query_update_changed(bodhi_mock, session):
 @mock_redis
 @mock_bodhi
 def test_list_updates_by_release(session):
-    refresh_updates(session, 'rpm', entities=['eog'])
+    refresh_updates(session, "rpm", entities=["eog"])
 
-    updates = list_updates(session, 'rpm', 'eog', release_branch='f36')
+    updates = list_updates(session, "rpm", "eog", release_branch="f36")
     assert len(updates) == 13
 
-    assert updates[0].builds == ['eog-41~beta-1.fc36']
+    assert updates[0].builds == ["eog-41~beta-1.fc36"]
 
-    updates = list_updates(session, 'rpm', release_branch='f36')
+    updates = list_updates(session, "rpm", release_branch="f36")
     assert len(updates) == 13
 
-    assert updates[0].builds == ['eog-41~beta-1.fc36']
+    assert updates[0].builds == ["eog-41~beta-1.fc36"]
 
 
 @mock_koji
 @mock_redis
 @mock_bodhi
 def test_bodhi_query_flatpak_updates(session):
-    refresh_all_updates(session, 'flatpak')
+    refresh_all_updates(session, "flatpak")
 
-    updates = list_updates(session, 'flatpak', 'feedreader')
+    updates = list_updates(session, "flatpak", "feedreader")
     assert len(updates) == 3
 
-    update = [x for x in updates if 'feedreader-stable-3520211013075828.3' in x.builds][0]
+    update = [x for x in updates if "feedreader-stable-3520211013075828.3" in x.builds][0]
 
     assert isinstance(update, BodhiUpdateModel)
 
-    assert update.user_name == 'pwalter'
-    assert update.date_submitted.strftime("%Y-%m-%d %H:%M:%S") == '2021-11-07 22:59:34'
-    assert update.builds == ['feedreader-stable-3520211013075828.3']
-    assert update.status == 'stable'
-    assert update.type == 'unspecified'
+    assert update.user_name == "pwalter"
+    assert update.date_submitted.strftime("%Y-%m-%d %H:%M:%S") == "2021-11-07 22:59:34"
+    assert update.builds == ["feedreader-stable-3520211013075828.3"]
+    assert update.status == "stable"
+    assert update.type == "unspecified"
 
-    refresh_all_updates(session, 'flatpak')
+    refresh_all_updates(session, "flatpak")
 
 
 @mock_koji
 @mock_redis
 @mock_bodhi
-@pytest.mark.parametrize('flags', [
-    [],
-    ['bad_total'],
-    ['ghost_updates'],
-])
+@pytest.mark.parametrize(
+    "flags",
+    [
+        [],
+        ["bad_total"],
+        ["ghost_updates"],
+    ],
+)
 def test_bodhi_query_flatpak_updates_all(session, bodhi_mock, flags):
     bodhi_mock.flags = flags
 
-    refresh_all_updates(session, 'flatpak')
+    refresh_all_updates(session, "flatpak")
 
-    updates = list_updates(session, 'flatpak')
+    updates = list_updates(session, "flatpak")
     assert len(updates) == 11
 
     build_map = {u.update_id: [b.name for b in u.builds] for u in updates}
 
     assert build_map == {
-        'FEDORA-FLATPAK-2021-1bda39b4d9': ['feedreader'],
-        'FEDORA-FLATPAK-2021-2db97225fd': ['eog'],
-        'FEDORA-FLATPAK-2021-47ba6c9e6e': ['feedreader'],
-        'FEDORA-FLATPAK-2021-4df18ed3c8': ['baobab'],
-        'FEDORA-FLATPAK-2021-56cf8de552': ['eog'],
-        'FEDORA-FLATPAK-2021-927f4d44b8': ['feedreader'],
-        'FEDORA-FLATPAK-2021-be7df1d070': ['eog'],
-        'FEDORA-FLATPAK-2021-cb6b3c0cad': ['quadrapassel'],
-        'FEDORA-FLATPAK-2022-274a792493': ['baobab', 'eog'],
-        'FEDORA-FLATPAK-2022-6e191c5e67': ['eog'],
-        'FEDORA-FLATPAK-2022-efcca6b48a': ['eog']
+        "FEDORA-FLATPAK-2021-1bda39b4d9": ["feedreader"],
+        "FEDORA-FLATPAK-2021-2db97225fd": ["eog"],
+        "FEDORA-FLATPAK-2021-47ba6c9e6e": ["feedreader"],
+        "FEDORA-FLATPAK-2021-4df18ed3c8": ["baobab"],
+        "FEDORA-FLATPAK-2021-56cf8de552": ["eog"],
+        "FEDORA-FLATPAK-2021-927f4d44b8": ["feedreader"],
+        "FEDORA-FLATPAK-2021-be7df1d070": ["eog"],
+        "FEDORA-FLATPAK-2021-cb6b3c0cad": ["quadrapassel"],
+        "FEDORA-FLATPAK-2022-274a792493": ["baobab", "eog"],
+        "FEDORA-FLATPAK-2022-6e191c5e67": ["eog"],
+        "FEDORA-FLATPAK-2022-efcca6b48a": ["eog"],
     }
 
 
@@ -182,22 +192,22 @@ def test_bodhi_query_flatpak_updates_all(session, bodhi_mock, flags):
 @mock_redis
 @mock_bodhi
 def test_bodhi_refresh_update_status(session):
-    update_id = 'FEDORA-FLATPAK-2022-274a792493'
+    update_id = "FEDORA-FLATPAK-2022-274a792493"
 
-    refresh_all_updates(session, 'flatpak')
-    update_raw = session.redis_client.get('update:' + update_id)
+    refresh_all_updates(session, "flatpak")
+    update_raw = session.redis_client.get("update:" + update_id)
     update = BodhiUpdateModel.from_json_text(update_raw)
-    update.status = 'pending'
-    session.redis_client.set('update:' + update_id, update.to_json_text())
+    update.status = "pending"
+    session.redis_client.set("update:" + update_id, update.to_json_text())
 
     refresh_update_status(session, update_id)
 
-    update_raw = session.redis_client.get('update:' + update_id)
+    update_raw = session.redis_client.get("update:" + update_id)
     update = BodhiUpdateModel.from_json_text(update_raw)
-    assert update.status == 'stable'
+    assert update.status == "stable"
 
     # This should do nothing
-    refresh_update_status(session, 'NO_SUCH_UPDATE')
+    refresh_update_status(session, "NO_SUCH_UPDATE")
 
 
 @mock_koji
@@ -206,17 +216,17 @@ def test_bodhi_refresh_update_status(session):
 def test_bodhi_update_cache_global(session, caplog):
     caplog.set_level(logging.INFO)
 
-    refresh_all_updates(session, 'flatpak')
+    refresh_all_updates(session, "flatpak")
     assert "submitted_since" not in caplog.text
     caplog.clear()
 
-    refresh_all_updates(session, 'flatpak')
+    refresh_all_updates(session, "flatpak")
     assert "submitted_since" in caplog.text
     caplog.clear()
 
     reset_update_cache(session)
 
-    refresh_all_updates(session, 'flatpak')
+    refresh_all_updates(session, "flatpak")
     assert "submitted_since" not in caplog.text
     caplog.clear()
 
@@ -227,17 +237,17 @@ def test_bodhi_update_cache_global(session, caplog):
 def test_bodhi_update_cache_per_package(session, caplog):
     caplog.set_level(logging.INFO)
 
-    refresh_updates(session, 'flatpak', entities=['feedreader'])
+    refresh_updates(session, "flatpak", entities=["feedreader"])
     assert "submitted_since" not in caplog.text
     caplog.clear()
 
-    refresh_updates(session, 'flatpak', entities=['feedreader'])
+    refresh_updates(session, "flatpak", entities=["feedreader"])
     assert "submitted_since" in caplog.text
     caplog.clear()
 
     reset_update_cache(session)
 
-    refresh_updates(session, 'flatpak', entities=['feedreader'])
+    refresh_updates(session, "flatpak", entities=["feedreader"])
     assert "submitted_since" not in caplog.text
     caplog.clear()
 
@@ -256,40 +266,50 @@ def test_query_releases(session):
 def test_query_releases_corner_cases(session, bodhi_mock, caplog):
     def modify_releases(release_json):
         # Branched
-        release_json.append({
-            "name": "F90",
-            "branch": "f90",
-            "dist_tag": "f90",
-            "state": "pending",
-        })
+        release_json.append(
+            {
+                "name": "F90",
+                "branch": "f90",
+                "dist_tag": "f90",
+                "state": "pending",
+            }
+        )
         # Branched and frozen
-        release_json.append({
-            "name": "F91",
-            "branch": "f91",
-            "dist_tag": "f91",
-            "state": "frozen",
-        })
+        release_json.append(
+            {
+                "name": "F91",
+                "branch": "f91",
+                "dist_tag": "f91",
+                "state": "frozen",
+            }
+        )
         # Skip because not F\d+$
-        release_json.append({
-            "name": "F91F",
-            "branch": "f91",
-            "dist_tag": "f90-flatpak",
-            "state": "current",
-        })
+        release_json.append(
+            {
+                "name": "F91F",
+                "branch": "f91",
+                "dist_tag": "f90-flatpak",
+                "state": "current",
+            }
+        )
         # Skip because disabled
-        release_json.append({
-            "name": "F92",
-            "branch": "f92",
-            "dist_tag": "f92",
-            "state": "disabled",
-        })
+        release_json.append(
+            {
+                "name": "F92",
+                "branch": "f92",
+                "dist_tag": "f92",
+                "state": "disabled",
+            }
+        )
         # Skip because unknown state
-        release_json.append({
-            "name": "F99",
-            "branch": "f99",
-            "dist_tag": "f99",
-            "state": "weird",
-        })
+        release_json.append(
+            {
+                "name": "F99",
+                "branch": "f99",
+                "dist_tag": "f99",
+                "state": "weird",
+            }
+        )
 
     bodhi_mock.modify_releases = modify_releases
     releases = query_releases(session)

--- a/tests/test_build_cache.py
+++ b/tests/test_build_cache.py
@@ -3,8 +3,8 @@ import yaml
 from flatpak_indexer.session import Session
 from flatpak_indexer.test.koji import mock_koji
 from flatpak_indexer.test.redis import mock_redis
-from .utils import get_config
 
+from .utils import get_config
 
 CONFIG = yaml.safe_load("""
 koji_config: brew
@@ -23,12 +23,12 @@ def test_build_cache(tmp_path):
 
     assert image_b is image_a
 
-    module_a = build_cache.get_module_build('baobab-stable-3620220517102805')
-    module_b = build_cache.get_module_build('baobab-stable-3620220517102805')
+    module_a = build_cache.get_module_build("baobab-stable-3620220517102805")
+    module_b = build_cache.get_module_build("baobab-stable-3620220517102805")
 
     assert module_b is module_a
 
-    package_b = build_cache.get_package_build('baobab-42.0-1.module_f36+14451+219d93a5')
-    package_a = build_cache.get_package_build('baobab-42.0-1.module_f36+14451+219d93a5')
+    package_b = build_cache.get_package_build("baobab-42.0-1.module_f36+14451+219d93a5")
+    package_a = build_cache.get_package_build("baobab-42.0-1.module_f36+14451+219d93a5")
 
     assert package_b is package_a

--- a/tests/test_cleaner.py
+++ b/tests/test_cleaner.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timedelta
-import os
 from unittest.mock import patch
+import os
 
 import yaml
 
@@ -8,8 +8,8 @@ from flatpak_indexer.cleaner import Cleaner
 from flatpak_indexer.models import TardiffResultModel
 from flatpak_indexer.test.redis import mock_redis
 from flatpak_indexer.utils import path_for_digest
-from .utils import get_config
 
+from .utils import get_config
 
 CONFIG = yaml.safe_load("""
 koji_config: brew
@@ -45,7 +45,7 @@ def test_cleaner(tmp_path):
 
     cleaner.reference(str(tmp_path / "deltas" / "abc.tardiff"))
 
-    with patch('flatpak_indexer.cleaner.datetime') as mock:
+    with patch("flatpak_indexer.cleaner.datetime") as mock:
         mock.now.return_value = datetime.now() + timedelta(seconds=100)
 
         cleaner.clean()
@@ -73,34 +73,26 @@ def test_clean_tardiff_results(tmp_path):
 
     cleaner = Cleaner(config)
 
-    result1 = TardiffResultModel(
-        status="success",
-        digest="sha256:1234",
-        size=42,
-        message=""
-    )
+    result1 = TardiffResultModel(status="success", digest="sha256:1234", size=42, message="")
     path1 = path_for_digest(config.deltas_dir, result1.digest, ".tardiff")
     os.makedirs(os.path.dirname(path1))
     with open(path1, "w"):
         pass
-    cleaner.redis.set('tardiff:result:task1', result1.to_json_text())
+    cleaner.redis.set("tardiff:result:task1", result1.to_json_text())
 
-    result2 = TardiffResultModel(
-        status="success",
-        digest="sha256:abcd",
-        size=42,
-        message=""
-    )
+    result2 = TardiffResultModel(status="success", digest="sha256:abcd", size=42, message="")
     path2 = path_for_digest(config.deltas_dir, result2.digest, ".tardiff")
     os.makedirs(os.path.dirname(path2))
     with open(path2, "w"):
         pass
-    cleaner.redis.set('tardiff:result:task2', result2.to_json_text())
+    cleaner.redis.set("tardiff:result:task2", result2.to_json_text())
 
     cleaner.reference(path1)
 
-    with patch('flatpak_indexer.cleaner.datetime') as mock, \
-         patch('flatpak_indexer.cleaner.CLEAN_RESULTS_BATCH_SIZE', 1):
+    with (
+        patch("flatpak_indexer.cleaner.datetime") as mock,
+        patch("flatpak_indexer.cleaner.CLEAN_RESULTS_BATCH_SIZE", 1),
+    ):
         mock.now.return_value = datetime.now() + timedelta(seconds=100)
 
         cleaner.clean()
@@ -108,5 +100,5 @@ def test_clean_tardiff_results(tmp_path):
     assert os.path.exists(path1)
     assert not os.path.exists(path2)
 
-    assert cleaner.redis.get('tardiff:result:task1') is not None
-    assert cleaner.redis.get('tardiff:result:task2') is None
+    assert cleaner.redis.get("tardiff:result:task1") is not None
+    assert cleaner.redis.get("tardiff:result:task2") is None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,6 +4,7 @@ from pytest import raises
 import yaml
 
 from flatpak_indexer.config import ConfigError, PyxisRegistryConfig
+
 from .utils import get_config, setup_client_cert
 
 BASIC_CONFIG = yaml.safe_load("""
@@ -110,9 +111,10 @@ def test_config_basic(tmp_path):
 
 def create_client_key_config(tmp_path, create_cert=True, create_key=True):
     config_data = deepcopy(BASIC_CONFIG)
-    registry_config_data = config_data['registries']['production']
-    registry_config_data['pyxis_client_cert'], registry_config_data['pyxis_client_key'] = \
+    registry_config_data = config_data["registries"]["production"]
+    registry_config_data["pyxis_client_cert"], registry_config_data["pyxis_client_key"] = (
         setup_client_cert(tmp_path, create_cert=create_cert, create_key=create_key)
+    )
 
     return config_data
 
@@ -130,131 +132,145 @@ def test_client_cert(tmp_path):
 def test_client_cert_missing(tmp_path):
     config_data = create_client_key_config(tmp_path, create_cert=False)
 
-    with raises(ConfigError,
-                match="client.crt does not exist"):
+    with raises(ConfigError, match="client.crt does not exist"):
         get_config(tmp_path, config_data)
 
 
 def test_client_key_missing(tmp_path):
     config_data = create_client_key_config(tmp_path, create_key=False)
 
-    with raises(ConfigError,
-                match="client.key does not exist"):
+    with raises(ConfigError, match="client.key does not exist"):
         get_config(tmp_path, config_data)
 
 
 def test_client_key_mismatch(tmp_path):
     config_data = create_client_key_config(tmp_path)
-    del config_data['registries']['production']['pyxis_client_cert']
+    del config_data["registries"]["production"]["pyxis_client_cert"]
 
-    with raises(ConfigError,
-                match="pyxis_client_cert and pyxis_client_key must be set together"):
+    with raises(ConfigError, match="pyxis_client_cert and pyxis_client_key must be set together"):
         get_config(tmp_path, config_data)
 
 
 def test_pyxis_url_missing(tmp_path):
     config_data = deepcopy(BASIC_CONFIG)
-    del config_data['registries']['production']['pyxis_url']
+    del config_data["registries"]["production"]["pyxis_url"]
 
-    with raises(ConfigError,
-                match=r'A value is required for registries/production/pyxis_url'):
+    with raises(ConfigError, match=r"A value is required for registries/production/pyxis_url"):
         get_config(tmp_path, config_data)
 
 
 def test_datasource_invalid(tmp_path):
     config_data = deepcopy(BASIC_CONFIG)
-    config_data['registries']['production']['datasource'] = 'INVALID'
-    with raises(ConfigError,
-                match=("registry/production: "
-                       "datasource must be 'pyxis', 'koji', or 'fedora'")):
+    config_data["registries"]["production"]["datasource"] = "INVALID"
+    with raises(
+        ConfigError, match=("registry/production: datasource must be 'pyxis', 'koji', or 'fedora'")
+    ):
         get_config(tmp_path, config_data)
 
 
 def test_repository_parse_replace_mismatched(tmp_path):
     config_data = deepcopy(BASIC_CONFIG)
-    del config_data['registries']['production2']['repository_replace']
-    with raises(ConfigError,
-                match=(r"registries/production2: "
-                       r"repository_parse and repository_replace must be set together")):
+    del config_data["registries"]["production2"]["repository_replace"]
+    with raises(
+        ConfigError,
+        match=(
+            r"registries/production2: "
+            r"repository_parse and repository_replace must be set together"
+        ),
+    ):
         get_config(tmp_path, config_data)
 
 
 def test_public_url_not_https(tmp_path):
     config_data = deepcopy(BASIC_CONFIG)
-    config_data['registries']['production']['public_url'] = 'ftp://registry.example.com'
-    with raises(ConfigError,
-                match=(r"registries/production: "
-                       r"public_url must be a https:// URL")):
+    config_data["registries"]["production"]["public_url"] = "ftp://registry.example.com"
+    with raises(
+        ConfigError,
+        match=(
+            r"registries/production: "
+            r"public_url must be a https:// URL"
+        ),
+    ):
         get_config(tmp_path, config_data)
 
 
 def test_registry_missing(tmp_path):
     config_data = deepcopy(BASIC_CONFIG)
-    del config_data['registries']['production']
-    with raises(ConfigError,
-                match="indexes/amd64: No registry config found for production"):
+    del config_data["registries"]["production"]
+    with raises(ConfigError, match="indexes/amd64: No registry config found for production"):
         get_config(tmp_path, config_data)
 
 
 def test_koji_tags_consistent(tmp_path):
     config_data = deepcopy(BASIC_CONFIG)
-    config_data['indexes']['brew-rc-amd64']['koji_tags'] = ['release-candidate', 'released']
-    with raises(ConfigError,
-                match=("indexes/brew-rc, indexes/brew-rc-amd64: "
-                       "koji_tags must be consistent for indexes with the same tag")):
+    config_data["indexes"]["brew-rc-amd64"]["koji_tags"] = ["release-candidate", "released"]
+    with raises(
+        ConfigError,
+        match=(
+            "indexes/brew-rc, indexes/brew-rc-amd64: "
+            "koji_tags must be consistent for indexes with the same tag"
+        ),
+    ):
         get_config(tmp_path, config_data)
 
 
 def test_koji_tags_extra(tmp_path):
     config_data = deepcopy(BASIC_CONFIG)
-    config_data['indexes']['fedora-testing']['koji_tags'] = ['f30']
-    with raises(ConfigError,
-                match="indexes/fedora-testing: koji_tags can only be set for the pyxis datasource"):
+    config_data["indexes"]["fedora-testing"]["koji_tags"] = ["f30"]
+    with raises(
+        ConfigError,
+        match="indexes/fedora-testing: koji_tags can only be set for the pyxis datasource",
+    ):
         get_config(tmp_path, config_data)
 
 
 def test_bodhi_status_extra(tmp_path):
     config_data = deepcopy(BASIC_CONFIG)
-    config_data['indexes']['amd64']['bodhi_status'] = 'stable'
-    with raises(ConfigError,
-                match="indexes/amd64: bodhi_status can only be set for the fedora datasource"):
+    config_data["indexes"]["amd64"]["bodhi_status"] = "stable"
+    with raises(
+        ConfigError, match="indexes/amd64: bodhi_status can only be set for the fedora datasource"
+    ):
         get_config(tmp_path, config_data)
 
 
 def test_bodhi_status_invalid(tmp_path):
     config_data = deepcopy(BASIC_CONFIG)
-    config_data['indexes']['fedora-testing']['bodhi_status'] = 'INVALID'
-    with raises(ConfigError,
-                match="indexes/fedora-testing: bodhi_status must be set to 'testing' or 'stable'"):
+    config_data["indexes"]["fedora-testing"]["bodhi_status"] = "INVALID"
+    with raises(
+        ConfigError,
+        match="indexes/fedora-testing: bodhi_status must be set to 'testing' or 'stable'",
+    ):
         get_config(tmp_path, config_data)
 
 
 def test_icons_dir_missing(tmp_path):
     config_data = deepcopy(BASIC_CONFIG)
-    del config_data['icons_dir']
-    with raises(ConfigError,
-                match="indexes/amd64: extract_icons is set, but no icons_dir is configured"):
+    del config_data["icons_dir"]
+    with raises(
+        ConfigError, match="indexes/amd64: extract_icons is set, but no icons_dir is configured"
+    ):
         get_config(tmp_path, config_data)
 
 
 def test_icons_uri_missing(tmp_path):
     config_data = deepcopy(BASIC_CONFIG)
-    del config_data['icons_uri']
+    del config_data["icons_uri"]
     with raises(ConfigError, match="icons_dir is configured, but not icons_uri"):
         get_config(tmp_path, config_data)
 
 
 def test_deltas_dir_missing(tmp_path):
     config_data = deepcopy(BASIC_CONFIG)
-    del config_data['deltas_dir']
-    with raises(ConfigError,
-                match=("indexes/fedora-testing: " +
-                       "delta_keep is set, but no deltas_dir is configured")):
+    del config_data["deltas_dir"]
+    with raises(
+        ConfigError,
+        match=("indexes/fedora-testing: " + "delta_keep is set, but no deltas_dir is configured"),
+    ):
         get_config(tmp_path, config_data)
 
 
 def test_deltas_uri_missing(tmp_path):
     config_data = deepcopy(BASIC_CONFIG)
-    del config_data['deltas_uri']
+    del config_data["deltas_uri"]
     with raises(ConfigError, match="deltas_dir is configured, but not deltas_uri"):
         get_config(tmp_path, config_data)

--- a/tests/test_delta_generator.py
+++ b/tests/test_delta_generator.py
@@ -6,7 +6,6 @@ import os
 import threading
 
 import pytest
-import redis
 import yaml
 
 from flatpak_indexer.cleaner import Cleaner
@@ -14,8 +13,9 @@ from flatpak_indexer.delta_generator import DeltaGenerator
 from flatpak_indexer.models import RepositoryModel, TardiffResultModel, TardiffSpecModel
 from flatpak_indexer.test.redis import mock_redis
 from flatpak_indexer.utils import path_for_digest
-from .utils import get_config
+import redis
 
+from .utils import get_config
 
 CONFIG = yaml.safe_load("""
 redis_url: redis://localhost
@@ -37,122 +37,115 @@ indexes:
 
 
 IMAGE1 = {
-    'Digest': 'sha256:a1b1c1d1e1f1',
-    'MediaType': 'application/vnd.oci.image.manifest.v1+json',
-    'OS': 'linux',
-    'Architecture': 'amd64',
-    'DiffIds': [
-        'sha256:image1_layer0',
+    "Digest": "sha256:a1b1c1d1e1f1",
+    "MediaType": "application/vnd.oci.image.manifest.v1+json",
+    "OS": "linux",
+    "Architecture": "amd64",
+    "DiffIds": [
+        "sha256:image1_layer0",
     ],
-    'PullSpec': 'registry.fedoraproject.org/baobab@sha256:a1b1c1d1e1f1'
+    "PullSpec": "registry.fedoraproject.org/baobab@sha256:a1b1c1d1e1f1",
 }
 
 IMAGE2 = {
-    'Digest': 'sha256:a2b2c2d2e2f2g2',
-    'MediaType': 'application/vnd.oci.image.manifest.v1+json',
-    'OS': 'linux',
-    'Architecture': 'amd64',
-    'DiffIds': [
-        'sha256:image2_layer0',
+    "Digest": "sha256:a2b2c2d2e2f2g2",
+    "MediaType": "application/vnd.oci.image.manifest.v1+json",
+    "OS": "linux",
+    "Architecture": "amd64",
+    "DiffIds": [
+        "sha256:image2_layer0",
     ],
-    'PullSpec': 'registry.fedoraproject.org/baobab@sha256:a2b2c2d2e2f2g2'
+    "PullSpec": "registry.fedoraproject.org/baobab@sha256:a2b2c2d2e2f2g2",
 }
 
 IMAGE3 = {
-    'Digest': 'sha256:a3b3c3d3e3f3',
-    'MediaType': 'application/vnd.oci.image.manifest.v1+json',
-    'OS': 'linux',
-    'Architecture': 'amd64',
-    'Tags': ['latest'],
-    'DiffIds': [
-        'sha256:image3_layer0',
+    "Digest": "sha256:a3b3c3d3e3f3",
+    "MediaType": "application/vnd.oci.image.manifest.v1+json",
+    "OS": "linux",
+    "Architecture": "amd64",
+    "Tags": ["latest"],
+    "DiffIds": [
+        "sha256:image3_layer0",
     ],
-    'PullSpec': 'registry.fedoraproject.org/baobab@sha256:a3b3c3d3e3f3'
+    "PullSpec": "registry.fedoraproject.org/baobab@sha256:a3b3c3d3e3f3",
 }
 
 IMAGE4 = {
-    'Digest': 'sha256:a4b4c4d4e4f4',
-    'MediaType': 'application/vnd.oci.image.manifest.v1+json',
-    'OS': 'linux',
-    'Architecture': 'ppc64le',
-    'Tags': [],
-    'DiffIds': [
-        'sha256:image4_layer0',
+    "Digest": "sha256:a4b4c4d4e4f4",
+    "MediaType": "application/vnd.oci.image.manifest.v1+json",
+    "OS": "linux",
+    "Architecture": "ppc64le",
+    "Tags": [],
+    "DiffIds": [
+        "sha256:image4_layer0",
     ],
-    'PullSpec': 'registry.fedoraproject.org/baobab@sha256:a4b4c4d4e4f4'
+    "PullSpec": "registry.fedoraproject.org/baobab@sha256:a4b4c4d4e4f4",
 }
 
 IMAGE5 = {
-    'Digest': 'sha256:a5b5c5d5e5f5',
-    'MediaType': 'application/vnd.oci.image.manifest.v1+json',
-    'OS': 'linux',
-    'Architecture': 'ppc64le',
-    'Tags': ['latest'],
-    'DiffIds': [
-        'sha256:image5_layer0',
+    "Digest": "sha256:a5b5c5d5e5f5",
+    "MediaType": "application/vnd.oci.image.manifest.v1+json",
+    "OS": "linux",
+    "Architecture": "ppc64le",
+    "Tags": ["latest"],
+    "DiffIds": [
+        "sha256:image5_layer0",
     ],
-    'PullSpec': 'registry.fedoraproject.org/baobab@sha256:a5b5c5d5e5f5'
+    "PullSpec": "registry.fedoraproject.org/baobab@sha256:a5b5c5d5e5f5",
 }
 
 IMAGE6 = {
-    'Digest': 'sha256:a6b6c6d6e6f4',
-    'MediaType': 'application/vnd.oci.image.manifest.v1+json',
-    'OS': 'linux',
-    'Architecture': 's390x',
-    'Tags': [],
-    'DiffIds': [
-        'sha256:image6_layer0',
+    "Digest": "sha256:a6b6c6d6e6f4",
+    "MediaType": "application/vnd.oci.image.manifest.v1+json",
+    "OS": "linux",
+    "Architecture": "s390x",
+    "Tags": [],
+    "DiffIds": [
+        "sha256:image6_layer0",
     ],
-    'PullSpec': 'registry.fedoraproject.org/baobab@sha256:a3b3c3d3e3f3'
+    "PullSpec": "registry.fedoraproject.org/baobab@sha256:a3b3c3d3e3f3",
 }
 
 REPOSITORY = {
-    'Name': 'baobab',
-    'Images': [
-        IMAGE1,
-        IMAGE2,
-        IMAGE3,
-        IMAGE4,
-        IMAGE5,
-        IMAGE6
-    ],
-    'TagHistories': [
+    "Name": "baobab",
+    "Images": [IMAGE1, IMAGE2, IMAGE3, IMAGE4, IMAGE5, IMAGE6],
+    "TagHistories": [
         {
-            'Name': "latest",
-            'Items': [
+            "Name": "latest",
+            "Items": [
                 {
-                    'Architecture': 'amd64',
-                    'Date': '2020-08-21T01:02:03.00000+00:00',
-                    'Digest': IMAGE3['Digest'],
+                    "Architecture": "amd64",
+                    "Date": "2020-08-21T01:02:03.00000+00:00",
+                    "Digest": IMAGE3["Digest"],
                 },
                 {
-                    'Architecture': 'ppc64le',
-                    'Date': '2020-08-21T01:02:03.00000+00:00',
-                    'Digest': IMAGE5['Digest'],
+                    "Architecture": "ppc64le",
+                    "Date": "2020-08-21T01:02:03.00000+00:00",
+                    "Digest": IMAGE5["Digest"],
                 },
                 {
-                    'Architecture': 'amd64',
-                    'Date': '2020-08-14T01:02:03.00000+00:00',
-                    'Digest': IMAGE2['Digest'],
+                    "Architecture": "amd64",
+                    "Date": "2020-08-14T01:02:03.00000+00:00",
+                    "Digest": IMAGE2["Digest"],
                 },
                 {
-                    'Architecture': 'ppc64le',
-                    'Date': '2020-08-14T01:02:03.00000+00:00',
-                    'Digest': IMAGE4['Digest'],
+                    "Architecture": "ppc64le",
+                    "Date": "2020-08-14T01:02:03.00000+00:00",
+                    "Digest": IMAGE4["Digest"],
                 },
                 {
-                    'Architecture': 's390x',
-                    'Date': '2020-08-14T01:02:03.00000+00:00',
-                    'Digest': IMAGE6['Digest'],
+                    "Architecture": "s390x",
+                    "Date": "2020-08-14T01:02:03.00000+00:00",
+                    "Digest": IMAGE6["Digest"],
                 },
                 {
-                    'Architecture': 'amd64',
-                    'Date': '2020-08-07T01:02:03.00000+00:00',
-                    'Digest': IMAGE1['Digest'],
-                }
-            ]
+                    "Architecture": "amd64",
+                    "Date": "2020-08-07T01:02:03.00000+00:00",
+                    "Digest": IMAGE1["Digest"],
+                },
+            ],
         }
-    ]
+    ],
 }
 
 
@@ -176,21 +169,21 @@ class FakeDiffer:
 
     def stop(self):
         redis_client = redis.Redis.from_url(self.config.redis_url)
-        redis_client.publish("fake-differ-exit", b'')
+        redis_client.publish("fake-differ-exit", b"")
         self.thread.join()
 
     def get_task(self, redis_client):
         with redis_client.pipeline() as pipe:
-            pipe.watch('tardiff:pending')
-            task_raw = redis_client.srandmember('tardiff:pending')
+            pipe.watch("tardiff:pending")
+            task_raw = redis_client.srandmember("tardiff:pending")
             if not task_raw:
                 return None
 
             task = task_raw.decode("utf-8")
 
             pipe.multi()
-            pipe.srem('tardiff:pending', task)
-            pipe.zadd('tardiff:progress', {task: datetime.now().timestamp()})
+            pipe.srem("tardiff:pending", task)
+            pipe.zadd("tardiff:progress", {task: datetime.now().timestamp()})
             try:
                 pipe.execute()
                 return task
@@ -207,14 +200,14 @@ class FakeDiffer:
 
         if destiny == "diff-error":
             # Should not be retried - if retried, we'll succeed unexpectedly
-            return TardiffResultModel(status="diff-error",
-                                      digest="", size=0,
-                                      message="tardiff failed")
+            return TardiffResultModel(
+                status="diff-error", digest="", size=0, message="tardiff failed"
+            )
         elif destiny == "download-error":
             # download errors are transient and should be tried
-            return TardiffResultModel(status="download-error",
-                                      digest="", size=0,
-                                      message="downloading layer failed")
+            return TardiffResultModel(
+                status="download-error", digest="", size=0, message="downloading layer failed"
+            )
         elif destiny == "stick":
             # Task sticks in queue, needs to be removed and retried immediately
             self.logger.info("Leaving task stuck in the progress state")
@@ -222,7 +215,7 @@ class FakeDiffer:
         elif destiny == "swallow":
             # Task vanishes without a trace, should be retried on next run
             self.logger.info("Making task disappear into the limbo")
-            redis_client.zrem('tardiff:progress', task)
+            redis_client.zrem("tardiff:progress", task)
             return
         else:
             assert destiny is None
@@ -230,34 +223,36 @@ class FakeDiffer:
             out_contents = f"Tardiff({spec.from_diff_id}, {spec.to_diff_id})".encode("UTF-8")
             h = hashlib.sha256()
             h.update(out_contents)
-            digest = 'sha256:' + h.hexdigest()
+            digest = "sha256:" + h.hexdigest()
 
-            with open(path_for_digest(self.config.deltas_dir,
-                                      digest, ".tardiff", create_subdir=True), "wb") as f:
+            with open(
+                path_for_digest(self.config.deltas_dir, digest, ".tardiff", create_subdir=True),
+                "wb",
+            ) as f:
                 f.write(out_contents)
 
-            return TardiffResultModel(status="success",
-                                      digest=digest, size=len(out_contents),
-                                      message="")
+            return TardiffResultModel(
+                status="success", digest=digest, size=len(out_contents), message=""
+            )
 
     def finish_task(self, redis_client, task, result):
         with redis_client.pipeline() as pipe:
             pipe.multi()
-            pipe.set(f'tardiff:result:{task}', result.to_json_text())
-            pipe.zrem('tardiff:progress', task)
-            if result.status == 'success':
-                pipe.zadd('tardiff:active', {task: datetime.now().timestamp()})
-            pipe.publish("tardiff:complete", b'')
+            pipe.set(f"tardiff:result:{task}", result.to_json_text())
+            pipe.zrem("tardiff:progress", task)
+            if result.status == "success":
+                pipe.zadd("tardiff:active", {task: datetime.now().timestamp()})
+            pipe.publish("tardiff:complete", b"")
             pipe.execute()
 
     def _run(self, redis_client, pubsub):
         for message in pubsub.listen():
             self.logger.info("Got message: %s", message)
-            if message['type'] == 'message':
-                if message['channel'] == b'fake-differ-exit':
+            if message["type"] == "message":
+                if message["channel"] == b"fake-differ-exit":
                     break
 
-            while redis_client.scard('tardiff:pending') > 0:
+            while redis_client.scard("tardiff:pending") > 0:
                 task = self.get_task(redis_client)
                 logging.info("Got task %s", task)
                 if task:
@@ -273,7 +268,7 @@ class FakeDiffer:
             redis_client = redis.Redis.from_url(self.config.redis_url)
             pubsub = redis_client.pubsub()
             pubsub.subscribe("fake-differ-exit")
-            pubsub.subscribe('tardiff:queued')
+            pubsub.subscribe("tardiff:queued")
 
             self._run(redis_client, pubsub)
         except Exception:
@@ -285,14 +280,17 @@ class FakeDiffer:
 
 
 @mock_redis
-@pytest.mark.parametrize('iterations', (1, 2))
-@pytest.mark.parametrize('task_destiny,layer_counts', [
-    (None,             (2, 2)),
-    ('diff-error',     (1, 1)),  # Should not be retried
-    ('download-error', (1, 2)),  # Should be retried on next pass
-    ('swallow',        (1, 2)),  # Should be retried on the next pass
-    ('stick',          (2, 2)),  # Should be removed and retried immediately
-])
+@pytest.mark.parametrize("iterations", (1, 2))
+@pytest.mark.parametrize(
+    "task_destiny,layer_counts",
+    [
+        (None, (2, 2)),
+        ("diff-error", (1, 1)),  # Should not be retried
+        ("download-error", (1, 2)),  # Should be retried on next pass
+        ("swallow", (1, 2)),  # Should be retried on the next pass
+        ("stick", (2, 2)),  # Should be removed and retried immediately
+    ],
+)
 def test_delta_generator(tmp_path, iterations, task_destiny, layer_counts):
     os.environ["OUTPUT_DIR"] = str(tmp_path)
     os.mkdir(tmp_path / "deltas")
@@ -302,16 +300,12 @@ def test_delta_generator(tmp_path, iterations, task_destiny, layer_counts):
     cleaner = Cleaner(config)
     generator = DeltaGenerator(config, progress_timeout_seconds=0.1, cleaner=cleaner)
 
-    index_config = next(index for index in config.indexes if index.name == 'stable')
+    index_config = next(index for index in config.indexes if index.name == "stable")
     repository = RepositoryModel.from_json(REPOSITORY)
 
-    generator.add_tag_history(repository,
-                              repository.tag_histories['latest'],
-                              index_config)
+    generator.add_tag_history(repository, repository.tag_histories["latest"], index_config)
 
-    task_destinies = {
-        'sha256:image2_layer0:sha256:image3_layer0': task_destiny
-    }
+    task_destinies = {"sha256:image2_layer0:sha256:image3_layer0": task_destiny}
 
     with FakeDiffer(config, task_destinies=task_destinies):
         for i in range(0, iterations):
@@ -319,7 +313,7 @@ def test_delta_generator(tmp_path, iterations, task_destiny, layer_counts):
             cleaner.clean()
             cleaner.reset()
 
-    url = generator.get_delta_manifest_url(IMAGE3['Digest'])
+    url = generator.get_delta_manifest_url(IMAGE3["Digest"])
     assert url is not None
     assert url.startswith("https://flatpaks.fedoraproject.org/deltas/")
 
@@ -329,15 +323,19 @@ def test_delta_generator(tmp_path, iterations, task_destiny, layer_counts):
 
     assert len(manifest["layers"]) == layer_counts[iterations - 1]
 
-    layer = next(lyr for lyr in manifest["layers"]
-                 if lyr["annotations"]["io.github.containers.delta.from"] == "sha256:image1_layer0")
+    layer = next(
+        lyr
+        for lyr in manifest["layers"]
+        if lyr["annotations"]["io.github.containers.delta.from"] == "sha256:image1_layer0"
+    )
 
     assert len(layer["urls"]) == 1
     assert layer["annotations"]["io.github.containers.delta.to"] == "sha256:image3_layer0"
 
     digest_url = layer["urls"][0]
-    digest_path = digest_url.replace("https://flatpaks.fedoraproject.org/deltas",
-                                     str(tmp_path / "deltas"))
+    digest_path = digest_url.replace(
+        "https://flatpaks.fedoraproject.org/deltas", str(tmp_path / "deltas")
+    )
 
     assert os.path.exists(digest_path)
 
@@ -368,25 +366,23 @@ def test_delta_generator_expire(tmp_path):
 
     generator = DeltaGenerator(config)
 
-    index_config = next(index for index in config.indexes if index.name == 'stable')
+    index_config = next(index for index in config.indexes if index.name == "stable")
     repository = RepositoryModel.from_json(REPOSITORY)
 
-    generator.add_tag_history(repository,
-                              repository.tag_histories['latest'],
-                              index_config)
+    generator.add_tag_history(repository, repository.tag_histories["latest"], index_config)
 
     with FakeDiffer(config):
         generator.generate()
 
         # Expire the deltas we just generated
         redis_client = redis.Redis.from_url(config.redis_url)
-        all_tardiffs_raw = redis_client.zrangebyscore('tardiff:active', 0, float("inf"))
+        all_tardiffs_raw = redis_client.zrangebyscore("tardiff:active", 0, float("inf"))
         all_tardiffs = (k.decode("utf-8") for k in all_tardiffs_raw)
         for result_raw in redis_client.mget(*(f"tardiff:result:{k}" for k in all_tardiffs)):
             assert result_raw is not None
             result = TardiffResultModel.from_json_text(result_raw)
             os.unlink(path_for_digest(config.deltas_dir, result.digest, ".tardiff"))
-        redis_client.delete('tardiff:active')
+        redis_client.delete("tardiff:active")
 
         generator.generate()
 
@@ -396,11 +392,15 @@ def test_delta_generator_expire(tmp_path):
 
     assert len(manifest["layers"]) == 2
 
-    layer = next(lyr for lyr in manifest["layers"]
-                 if lyr["annotations"]["io.github.containers.delta.from"] == "sha256:image1_layer0")
+    layer = next(
+        lyr
+        for lyr in manifest["layers"]
+        if lyr["annotations"]["io.github.containers.delta.from"] == "sha256:image1_layer0"
+    )
 
     digest_url = layer["urls"][0]
-    digest_path = digest_url.replace("https://flatpaks.fedoraproject.org/deltas",
-                                     str(tmp_path / "deltas"))
+    digest_path = digest_url.replace(
+        "https://flatpaks.fedoraproject.org/deltas", str(tmp_path / "deltas")
+    )
 
     assert os.path.exists(digest_path)

--- a/tests/test_differ.py
+++ b/tests/test_differ.py
@@ -3,15 +3,15 @@ import threading
 import time
 
 import pytest
-import redis
 import yaml
 
 from flatpak_indexer.differ import Differ
 from flatpak_indexer.models import TardiffImageModel, TardiffResultModel, TardiffSpecModel
 from flatpak_indexer.test.redis import mock_redis
+import redis
+
 from .registry import mock_registry
 from .utils import get_config, timeout_first_popen_wait
-
 
 CONFIG = yaml.safe_load("""
 redis_url: redis://localhost
@@ -34,20 +34,21 @@ def config(tmp_path):
 
 
 def image_model(ref):
-    return TardiffImageModel(registry='https://registry.fedoraproject.org',
-                             repository='ghex',
-                             ref=ref)
+    return TardiffImageModel(
+        registry="https://registry.fedoraproject.org", repository="ghex", ref=ref
+    )
 
 
-def queue_task(from_ref, from_diff_id, to_ref, to_diff_id,
-               redis_client=None, skip_spec=False):
+def queue_task(from_ref, from_diff_id, to_ref, to_diff_id, redis_client=None, skip_spec=False):
     if not redis_client:
         redis_client = redis.Redis.from_url("redis://localhost")
 
-    spec = TardiffSpecModel(from_image=image_model(from_ref),
-                            from_diff_id=from_diff_id,
-                            to_image=image_model(to_ref),
-                            to_diff_id=to_diff_id)
+    spec = TardiffSpecModel(
+        from_image=image_model(from_ref),
+        from_diff_id=from_diff_id,
+        to_image=image_model(to_ref),
+        to_diff_id=to_diff_id,
+    )
 
     key = f"{from_diff_id}:{to_diff_id}"
 
@@ -61,9 +62,9 @@ def queue_task(from_ref, from_diff_id, to_ref, to_diff_id,
 def check_success(key, old_layer, new_layer):
     redis_client = redis.Redis.from_url("redis://localhost")
 
-    assert redis_client.scard('tardiff:pending') == 0
-    assert redis_client.zscore('tardiff:progress', key) is None
-    assert redis_client.zscore('tardiff:active', key) is not None
+    assert redis_client.scard("tardiff:pending") == 0
+    assert redis_client.zscore("tardiff:progress", key) is None
+    assert redis_client.zscore("tardiff:active", key) is not None
 
     result_raw = redis_client.get(f"tardiff:result:{key}")
     assert result_raw is not None
@@ -84,9 +85,9 @@ def check_success(key, old_layer, new_layer):
 def check_failure(key, status, message):
     redis_client = redis.Redis.from_url("redis://localhost")
 
-    assert redis_client.scard('tardiff:pending') == 0
-    assert redis_client.zscore('tardiff:progress', key) is None
-    assert redis_client.zscore('tardiff:active', key) is None
+    assert redis_client.scard("tardiff:pending") == 0
+    assert redis_client.zscore("tardiff:progress", key) is None
+    assert redis_client.zscore("tardiff:active", key) is None
 
     result_raw = redis_client.get(f"tardiff:result:{key}")
     assert result_raw is not None
@@ -98,15 +99,14 @@ def check_failure(key, status, message):
 
 
 @mock_redis
-@mock_registry(registry='registry.fedoraproject.org')
+@mock_registry(registry="registry.fedoraproject.org")
 def test_differ(registry_mock, config):
-    old_manifest_digest, old_layer = registry_mock.add_fake_image('ghex', 'latest')
-    new_manifest_digest, new_layer = registry_mock.add_fake_image('ghex', 'latest')
+    old_manifest_digest, old_layer = registry_mock.add_fake_image("ghex", "latest")
+    new_manifest_digest, new_layer = registry_mock.add_fake_image("ghex", "latest")
 
     key = f"{old_layer.diff_id}:{new_layer.diff_id}"
 
-    key = queue_task(old_manifest_digest, old_layer.diff_id,
-                     new_manifest_digest, new_layer.diff_id)
+    key = queue_task(old_manifest_digest, old_layer.diff_id, new_manifest_digest, new_layer.diff_id)
 
     differ = Differ(config)
     differ.run(max_tasks=1)
@@ -115,79 +115,88 @@ def test_differ(registry_mock, config):
 
 
 @mock_redis
-@mock_registry(registry='registry.fedoraproject.org')
+@mock_registry(registry="registry.fedoraproject.org")
 def test_differ_no_spec(registry_mock, config):
-    old_manifest_digest, old_layer = registry_mock.add_fake_image('ghex', 'latest')
-    new_manifest_digest, new_layer = registry_mock.add_fake_image('ghex', 'latest')
+    old_manifest_digest, old_layer = registry_mock.add_fake_image("ghex", "latest")
+    new_manifest_digest, new_layer = registry_mock.add_fake_image("ghex", "latest")
 
     key = f"{old_layer.diff_id}:{new_layer.diff_id}"
 
-    key = queue_task(old_manifest_digest, old_layer.diff_id,
-                     new_manifest_digest, new_layer.diff_id,
-                     skip_spec=True)
+    key = queue_task(
+        old_manifest_digest,
+        old_layer.diff_id,
+        new_manifest_digest,
+        new_layer.diff_id,
+        skip_spec=True,
+    )
 
     differ = Differ(config)
     differ.run(max_tasks=1)
 
-    check_failure(key, 'no-spec-error',
-                  "failed to find spec")
+    check_failure(key, "no-spec-error", "failed to find spec")
 
 
 @mock_redis
-@mock_registry(registry='registry.fedoraproject.org')
-@pytest.mark.parametrize('fail_from, fail_to', [
-    (True, False),
-    (False, True),
-])
+@mock_registry(registry="registry.fedoraproject.org")
+@pytest.mark.parametrize(
+    "fail_from, fail_to",
+    [
+        (True, False),
+        (False, True),
+    ],
+)
 def test_differ_tardiff_download_error(registry_mock, config, fail_from, fail_to):
     if fail_from:
-        old_manifest_digest, old_diff_id = 'sha256:not-there', 'whatever'
+        old_manifest_digest, old_diff_id = "sha256:not-there", "whatever"
     else:
-        old_manifest_digest, old_layer = registry_mock.add_fake_image('ghex', 'latest',
-                                                                      layer_contents=b"GARBAGE")
+        old_manifest_digest, old_layer = registry_mock.add_fake_image(
+            "ghex", "latest", layer_contents=b"GARBAGE"
+        )
         old_diff_id = old_layer.diff_id
 
     if fail_to:
-        new_manifest_digest, new_diff_id = 'sha256:not-there', 'whatever'
+        new_manifest_digest, new_diff_id = "sha256:not-there", "whatever"
     else:
-        new_manifest_digest, new_layer = registry_mock.add_fake_image('ghex', 'latest',
-                                                                      layer_contents=b"GARBAGE")
+        new_manifest_digest, new_layer = registry_mock.add_fake_image(
+            "ghex", "latest", layer_contents=b"GARBAGE"
+        )
         new_diff_id = new_layer.diff_id
 
-    key = queue_task(old_manifest_digest, old_diff_id,
-                     new_manifest_digest, new_diff_id)
+    key = queue_task(old_manifest_digest, old_diff_id, new_manifest_digest, new_diff_id)
 
     differ = Differ(config)
     differ.run(max_tasks=1)
 
-    check_failure(key, 'download-error',
-                  "downloading from layer failed" if fail_from else "downloading to layer failed")
+    check_failure(
+        key,
+        "download-error",
+        "downloading from layer failed" if fail_from else "downloading to layer failed",
+    )
 
 
 @mock_redis
-@mock_registry(registry='registry.fedoraproject.org')
+@mock_registry(registry="registry.fedoraproject.org")
 def test_differ_tardiff_failure(registry_mock, config):
-    old_manifest_digest, old_layer = registry_mock.add_fake_image('ghex', 'latest',
-                                                                  layer_contents=b"GARBAGE")
-    new_manifest_digest, new_layer = registry_mock.add_fake_image('ghex', 'latest')
+    old_manifest_digest, old_layer = registry_mock.add_fake_image(
+        "ghex", "latest", layer_contents=b"GARBAGE"
+    )
+    new_manifest_digest, new_layer = registry_mock.add_fake_image("ghex", "latest")
 
-    key = queue_task(old_manifest_digest, old_layer.diff_id,
-                     new_manifest_digest, new_layer.diff_id)
+    key = queue_task(old_manifest_digest, old_layer.diff_id, new_manifest_digest, new_layer.diff_id)
 
     differ = Differ(config)
     differ.run(max_tasks=1)
 
-    check_failure(key, 'diff-error', "tardiff failed")
+    check_failure(key, "diff-error", "tardiff failed")
 
 
 @mock_redis
-@mock_registry(registry='registry.fedoraproject.org')
+@mock_registry(registry="registry.fedoraproject.org")
 def test_differ_tardiff_slow(registry_mock, config):
-    old_manifest_digest, old_layer = registry_mock.add_fake_image('ghex', 'latest')
-    new_manifest_digest, new_layer = registry_mock.add_fake_image('ghex', 'latest')
+    old_manifest_digest, old_layer = registry_mock.add_fake_image("ghex", "latest")
+    new_manifest_digest, new_layer = registry_mock.add_fake_image("ghex", "latest")
 
-    key = queue_task(old_manifest_digest, old_layer.diff_id,
-                     new_manifest_digest, new_layer.diff_id)
+    key = queue_task(old_manifest_digest, old_layer.diff_id, new_manifest_digest, new_layer.diff_id)
 
     with timeout_first_popen_wait():
         differ = Differ(config)
@@ -197,10 +206,10 @@ def test_differ_tardiff_slow(registry_mock, config):
 
 
 @mock_redis
-@mock_registry(registry='registry.fedoraproject.org')
+@mock_registry(registry="registry.fedoraproject.org")
 def test_differ_wait(registry_mock, config):
-    old_manifest_digest, old_layer = registry_mock.add_fake_image('ghex', 'latest')
-    new_manifest_digest, new_layer = registry_mock.add_fake_image('ghex', 'latest')
+    old_manifest_digest, old_layer = registry_mock.add_fake_image("ghex", "latest")
+    new_manifest_digest, new_layer = registry_mock.add_fake_image("ghex", "latest")
 
     key = f"{old_layer.diff_id}:{new_layer.diff_id}"
 
@@ -210,16 +219,20 @@ def test_differ_wait(registry_mock, config):
         time.sleep(0.1)
 
         # "stale old messages"
-        redis_client.publish('tardiff:queued', b'')
-        redis_client.publish('tardiff:queued', b'')
+        redis_client.publish("tardiff:queued", b"")
+        redis_client.publish("tardiff:queued", b"")
 
         time.sleep(0.1)
 
-        queue_task(old_manifest_digest, old_layer.diff_id,
-                   new_manifest_digest, new_layer.diff_id,
-                   redis_client=redis_client)
+        queue_task(
+            old_manifest_digest,
+            old_layer.diff_id,
+            new_manifest_digest,
+            new_layer.diff_id,
+            redis_client=redis_client,
+        )
 
-        redis_client.publish('tardiff:queued', b'')
+        redis_client.publish("tardiff:queued", b"")
 
     fill_queue_thread = threading.Thread(target=run_thread, name="fill-queue")
 

--- a/tests/test_http_utils.py
+++ b/tests/test_http_utils.py
@@ -1,6 +1,6 @@
-import os
 from socket import error as SocketError
 from unittest.mock import ANY, patch
+import os
 
 from pytest import raises
 import yaml
@@ -10,17 +10,13 @@ from flatpak_indexer.http_utils import HttpConfig
 
 
 def get_config(pyxis_cert):
-    config_data = {
-        'local_certs': {
-            'pyxis.example.com': pyxis_cert
-        }
-    }
+    config_data = {"local_certs": {"pyxis.example.com": pyxis_cert}}
     return HttpConfig.from_str(yaml.safe_dump(config_data))
 
 
 def test_cert_relative(tmp_path):
-    conf = get_config('test.crt')
-    cert = conf.find_local_cert('https://pyxis.example.com')
+    conf = get_config("test.crt")
+    cert = conf.find_local_cert("https://pyxis.example.com")
     assert cert is not None
     assert os.path.isabs(cert)
     assert os.path.exists(cert)
@@ -32,21 +28,21 @@ def test_cert_missing(tmp_path):
 
 
 def test_cert_no_host(tmp_path):
-    conf = get_config('test.crt')
-    cert = conf.find_local_cert('/no/host')
+    conf = get_config("test.crt")
+    cert = conf.find_local_cert("/no/host")
     assert cert is None
 
 
 def test_get_requests_session(tmp_path):
-    config = get_config('test.crt')
+    config = get_config("test.crt")
     session = config.get_requests_session(backoff_factor=0)
 
-    with patch("urllib3.connectionpool.HTTPConnectionPool._make_request",
-               side_effect=SocketError), \
-         patch("requests.adapters.HTTPAdapter.cert_verify") as p:
-
+    with (
+        patch("urllib3.connectionpool.HTTPConnectionPool._make_request", side_effect=SocketError),
+        patch("requests.adapters.HTTPAdapter.cert_verify") as p,
+    ):
         with raises(Exception, match="Max retries exceeded with url"):
-            session.get('https://pyxis.example.com/')
+            session.get("https://pyxis.example.com/")
 
         p.assert_called_once()
         assert p.call_args[0][2].endswith("/test.crt")
@@ -55,9 +51,9 @@ def test_get_requests_session(tmp_path):
 
         # Check that we pass verify=True for other URLs
         with raises(Exception, match="Max retries exceeded with url"):
-            session.get('https://other.example.com/')
+            session.get("https://other.example.com/")
 
         ca_bundle = os.environ.get("REQUESTS_CA_BUNDLE")  # None or path to system ca bundle
         p.assert_called_once_with(
-            ANY, 'https://other.example.com/', ca_bundle if ca_bundle else True, None
+            ANY, "https://other.example.com/", ca_bundle if ca_bundle else True, None
         )

--- a/tests/test_indexer.py
+++ b/tests/test_indexer.py
@@ -1,7 +1,7 @@
+from typing import Dict
 import copy
 import json
 import os
-from typing import Dict
 
 import yaml
 
@@ -12,6 +12,7 @@ from flatpak_indexer.models import RegistryModel
 from flatpak_indexer.test.bodhi import mock_bodhi
 from flatpak_indexer.test.koji import mock_koji
 from flatpak_indexer.test.redis import mock_redis
+
 from .fedora_messaging import mock_fedora_messaging
 from .pyxis import mock_pyxis
 from .test_delta_generator import FakeDiffer
@@ -108,27 +109,30 @@ def test_indexer(tmp_path):
     with open(tmp_path / "test/flatpak-amd64.json") as f:
         amd64_data = json.load(f)
 
-    assert amd64_data['Registry'] == 'https://registry.example.com/'
-    assert len(amd64_data['Results']) == 2
-    aisleriot_repository = [r for r in amd64_data['Results'] if r['Name'] == 'el8/aisleriot'][0]
-    assert len(aisleriot_repository['Images']) == 1
-    aisleriot_image = aisleriot_repository['Images'][0]
-    assert aisleriot_image['Digest'] == \
-        'sha256:bo1dfacec4d226da18ec4a6386263d8b2125fc874c8b4f4f97b31593037ea0bb'
-    assert aisleriot_image['Labels']['org.flatpak.ref'] == \
-        'app/org.gnome.Aisleriot/x86_64/stable'
-    assert aisleriot_image['Labels']['org.freedesktop.appstream.icon-128'] == \
-        "https://www.example.com/icons/aisleriot.png"
+    assert amd64_data["Registry"] == "https://registry.example.com/"
+    assert len(amd64_data["Results"]) == 2
+    aisleriot_repository = [r for r in amd64_data["Results"] if r["Name"] == "el8/aisleriot"][0]
+    assert len(aisleriot_repository["Images"]) == 1
+    aisleriot_image = aisleriot_repository["Images"][0]
+    assert (
+        aisleriot_image["Digest"]
+        == "sha256:bo1dfacec4d226da18ec4a6386263d8b2125fc874c8b4f4f97b31593037ea0bb"
+    )
+    assert aisleriot_image["Labels"]["org.flatpak.ref"] == "app/org.gnome.Aisleriot/x86_64/stable"
+    assert (
+        aisleriot_image["Labels"]["org.freedesktop.appstream.icon-128"]
+        == "https://www.example.com/icons/aisleriot.png"
+    )
 
-    assert aisleriot_image.get('Annotations', {}).get('org.flatpak.ref') is None
+    assert aisleriot_image.get("Annotations", {}).get("org.flatpak.ref") is None
 
-    assert 'PullSpec' not in aisleriot_image
-    assert 'DiffIds' not in aisleriot_image
+    assert "PullSpec" not in aisleriot_image
+    assert "DiffIds" not in aisleriot_image
 
-    icon_url = aisleriot_image['Labels']['org.freedesktop.appstream.icon-64']
-    assert icon_url.startswith('https://flatpaks.example.com/icons')
-    icon_subpath = icon_url.split('/')[-2:]
-    assert (tmp_path / 'icons' / icon_subpath[0] / icon_subpath[1]).exists()
+    icon_url = aisleriot_image["Labels"]["org.freedesktop.appstream.icon-64"]
+    assert icon_url.startswith("https://flatpaks.example.com/icons")
+    icon_subpath = icon_url.split("/")[-2:]
+    assert (tmp_path / "icons" / icon_subpath[0] / icon_subpath[1]).exists()
 
     assert not (tmp_path / "icons" / "ba" / "bbled.png").exists()
 
@@ -137,19 +141,21 @@ def test_indexer(tmp_path):
     with open(tmp_path / "test/flatpak-amd64-reversed.json") as f:
         reversed_data = json.load(f)
 
-    assert len(reversed_data['Results']) == 2
-    aisleriot_repository = [r for r in reversed_data['Results'] if r['Name'] == 'el9/aisleriot'][0]
-    assert len(aisleriot_repository['Images']) == 1
-    aisleriot_image = aisleriot_repository['Images'][0]
-    assert aisleriot_image['Digest'] == \
-        'sha256:ba5eba11c4d226da18ec4a6386263d8b2125fc874c8b4f4f97b31593037ea0bb'
+    assert len(reversed_data["Results"]) == 2
+    aisleriot_repository = [r for r in reversed_data["Results"] if r["Name"] == "el9/aisleriot"][0]
+    assert len(aisleriot_repository["Images"]) == 1
+    aisleriot_image = aisleriot_repository["Images"][0]
+    assert (
+        aisleriot_image["Digest"]
+        == "sha256:ba5eba11c4d226da18ec4a6386263d8b2125fc874c8b4f4f97b31593037ea0bb"
+    )
 
     # Check that limiting the repository set works
 
     with open(tmp_path / "test/flatpak-el9.json") as f:
         el9_data = json.load(f)
 
-        assert all(r['Name'].startswith('el9/') for r in el9_data['Results'])
+        assert all(r["Name"].startswith("el9/") for r in el9_data["Results"])
 
     # Now check that the index with flatpak_annotations set has the Flatpak
     # metadata in the annotations, not in the labels.
@@ -157,14 +163,15 @@ def test_indexer(tmp_path):
     with open(tmp_path / "test/flatpak-amd64-annotations.json") as f:
         amd64_data = json.load(f)
 
-    aisleriot_repository = [r for r in amd64_data['Results'] if r['Name'] == 'el8/aisleriot'][0]
-    aisleriot_image = aisleriot_repository['Images'][0]
-    assert aisleriot_image['Annotations']['org.flatpak.ref'] == \
-        'app/org.gnome.Aisleriot/x86_64/stable'
-    assert aisleriot_image.get('Labels', {}).get('org.flatpak.ref') is None
+    aisleriot_repository = [r for r in amd64_data["Results"] if r["Name"] == "el8/aisleriot"][0]
+    aisleriot_image = aisleriot_repository["Images"][0]
+    assert (
+        aisleriot_image["Annotations"]["org.flatpak.ref"] == "app/org.gnome.Aisleriot/x86_64/stable"
+    )
+    assert aisleriot_image.get("Labels", {}).get("org.flatpak.ref") is None
 
-    icon_url = aisleriot_image['Annotations']['org.freedesktop.appstream.icon-64']
-    assert icon_url.startswith('https://flatpaks.example.com/icons')
+    icon_url = aisleriot_image["Annotations"]["org.freedesktop.appstream.icon-64"]
+    assert icon_url.startswith("https://flatpaks.example.com/icons")
 
 
 @mock_brew
@@ -213,16 +220,17 @@ def test_indexer_koji(tmp_path):
     with open(tmp_path / "test/brew.json") as f:
         data = json.load(f)
 
-    assert data['Registry'] == 'https://internal.example.com/'
-    assert len(data['Results']) == 1
-    aisleriot_repository = data['Results'][0]
-    assert aisleriot_repository['Name'] == 'rh-osbs/aisleriot'
-    assert len(aisleriot_repository['Images']) == 1
-    aisleriot_image = aisleriot_repository['Images'][0]
-    assert aisleriot_image['Digest'] == \
-        'sha256:bo1dfacec4d226da18ec4a6386263d8b2125fc874c8b4f4f97b31593037ea0bb'
-    assert aisleriot_image['Labels']['org.flatpak.commit-metadata.xa.token-type'] == \
-        'AQAAAABp'
+    assert data["Registry"] == "https://internal.example.com/"
+    assert len(data["Results"]) == 1
+    aisleriot_repository = data["Results"][0]
+    assert aisleriot_repository["Name"] == "rh-osbs/aisleriot"
+    assert len(aisleriot_repository["Images"]) == 1
+    aisleriot_image = aisleriot_repository["Images"][0]
+    assert (
+        aisleriot_image["Digest"]
+        == "sha256:bo1dfacec4d226da18ec4a6386263d8b2125fc874c8b4f4f97b31593037ea0bb"
+    )
+    assert aisleriot_image["Labels"]["org.flatpak.commit-metadata.xa.token-type"] == "AQAAAABp"
 
 
 FEDORA_CONFIG = yaml.safe_load("""
@@ -255,9 +263,9 @@ indexes:
 def modify_statuses(update):
     # This build is now obsoleted by a build not in our test date, mark it testing so that
     # we have a repository with different stable/testing
-    if update['builds'][0]['nvr'] == 'feedreader-master-2920190201081220.1':
+    if update["builds"][0]["nvr"] == "feedreader-master-2920190201081220.1":
         update = copy.copy(update)
-        update['status'] = 'testing'
+        update["status"] = "testing"
 
     return update
 
@@ -283,35 +291,39 @@ def test_indexer_fedora(connection_mock, tmp_path):
     with open(tmp_path / "test/flatpak-latest.json") as f:
         data = json.load(f)
 
-    assert data['Registry'] == 'https://registry.fedoraproject.org/'
-    assert len(data['Results']) == 4
+    assert data["Registry"] == "https://registry.fedoraproject.org/"
+    assert len(data["Results"]) == 4
 
-    eog_repository = [r for r in data['Results'] if r['Name'] == 'eog'][0]
-    assert len(eog_repository['Images']) == 2
-    assert sorted(i['Architecture'] for i in eog_repository['Images']) == ['amd64', 'arm64']
-    assert eog_repository['Images'][0]['Tags'] == ['latest', 'testing']
+    eog_repository = [r for r in data["Results"] if r["Name"] == "eog"][0]
+    assert len(eog_repository["Images"]) == 2
+    assert sorted(i["Architecture"] for i in eog_repository["Images"]) == ["amd64", "arm64"]
+    assert eog_repository["Images"][0]["Tags"] == ["latest", "testing"]
 
-    feedreader_repository = [r for r in data['Results'] if r['Name'] == 'feedreader'][0]
-    assert len(feedreader_repository['Images']) == 2
-    assert sorted(i['Architecture'] for i in feedreader_repository['Images']) == ['amd64', 'arm64']
-    assert feedreader_repository['Images'][0]['Tags'] == ['latest', 'testing']
+    feedreader_repository = [r for r in data["Results"] if r["Name"] == "feedreader"][0]
+    assert len(feedreader_repository["Images"]) == 2
+    assert sorted(i["Architecture"] for i in feedreader_repository["Images"]) == ["amd64", "arm64"]
+    assert feedreader_repository["Images"][0]["Tags"] == ["latest", "testing"]
 
-    baobab_repository = [r for r in data['Results'] if r['Name'] == 'baobab'][0]
-    assert len(baobab_repository['Images']) == 2
+    baobab_repository = [r for r in data["Results"] if r["Name"] == "baobab"][0]
+    assert len(baobab_repository["Images"]) == 2
 
-    baobab_image = [i for i in baobab_repository['Images'] if i['Architecture'] == 'amd64'][0]
-    assert baobab_image['Labels']['org.flatpak.ref'] == 'app/org.gnome.baobab/x86_64/stable'
+    baobab_image = [i for i in baobab_repository["Images"] if i["Architecture"] == "amd64"][0]
+    assert baobab_image["Labels"]["org.flatpak.ref"] == "app/org.gnome.baobab/x86_64/stable"
 
     with open(tmp_path / "test/contents/latest/modules/baobab:stable.json") as f:
         module_data = json.load(f)
 
     assert module_data == {
-        'Images': [{
-            'ImageNvr': 'baobab-stable-3620220517102805.1',
-            'ModuleNvr': 'baobab-stable-3620220517102805.cab77b58',
-            'PackageBuilds': [
-                  {'Nvr': 'baobab-42.0-1.module_f36+14451+219d93a5',
-                   'SourceNvr': 'baobab-42.0-1.module_f36+14451+219d93a5'}
-              ]
-        }]
+        "Images": [
+            {
+                "ImageNvr": "baobab-stable-3620220517102805.1",
+                "ModuleNvr": "baobab-stable-3620220517102805.cab77b58",
+                "PackageBuilds": [
+                    {
+                        "Nvr": "baobab-42.0-1.module_f36+14451+219d93a5",
+                        "SourceNvr": "baobab-42.0-1.module_f36+14451+219d93a5",
+                    }
+                ],
+            }
+        ]
     }

--- a/tests/test_json_model.py
+++ b/tests/test_json_model.py
@@ -67,9 +67,9 @@ class DateTimeStuff(BaseModel):
 
 
 def test_datetime_field():
-    obj = DateTimeStuff(f1=datetime(year=2020, month=8, day=13,
-                                    hour=1, minute=2, second=3,
-                                    tzinfo=timezone.utc))
+    obj = DateTimeStuff(
+        f1=datetime(year=2020, month=8, day=13, hour=1, minute=2, second=3, tzinfo=timezone.utc)
+    )
     JSON = {"F1": "2020-08-13T01:02:03.000000+00:00"}
 
     assert obj.to_json() == JSON
@@ -99,7 +99,7 @@ class ClassStuff(BaseModel):
 
 
 def test_class_field():
-    obj = ClassStuff(f1=StringStuff(f1='foo'))
+    obj = ClassStuff(f1=StringStuff(f1="foo"))
     JSON = {"F1": {"F1": "foo"}}
 
     assert obj.to_json() == JSON
@@ -115,12 +115,7 @@ class ListStuff(BaseModel):
 
 def test_list_field():
     obj = ListStuff(f1=["foo"], f2=[StringStuff(f1="foo")])
-    JSON = {
-        "F1": ["foo"],
-        "F2": [
-            {"F1": "foo"}
-        ]
-    }
+    JSON = {"F1": ["foo"], "F2": [{"F1": "foo"}]}
 
     assert obj.to_json() == JSON
 
@@ -141,12 +136,7 @@ class IndexedListStuff(BaseModel):
 
 def test_indexed_list_field():
     obj = IndexedListStuff(f1={"foo": StringStuff(f1="foo"), "bar": StringStuff(f1="bar")})
-    JSON = {
-        "F1": [
-            {"F1": "bar"},
-            {"F1": "foo"}
-        ]
-    }
+    JSON = {"F1": [{"F1": "bar"}, {"F1": "foo"}]}
 
     assert obj.to_json() == JSON
 
@@ -162,9 +152,9 @@ def test_indexed_list_field():
 
 def test_indexed_list_mismatch_field():
     with pytest.raises(
-        TypeError,
-        match=r"f1: field\(index=<name>\) can only be used with Dict\[str\]"
+        TypeError, match=r"f1: field\(index=<name>\) can only be used with Dict\[str\]"
     ):
+
         class IndexedListMismatchStuff(BaseModel):
             f1: List[StringStuff] = field(index="f1")
 
@@ -199,10 +189,7 @@ class NameStuff(BaseModel):
 def test_field_names():
     obj = NameStuff(foo_bar="a", os="linux")
 
-    assert obj.to_json() == {
-        "FooBar": "a",
-        "OS": "linux"
-    }
+    assert obj.to_json() == {"FooBar": "a", "OS": "linux"}
 
 
 class InheritedStuff(StringStuff):
@@ -226,10 +213,10 @@ def test_optional_field():
     assert obj.to_json() == {}
 
     obj = OptionalStuff(f1=42)
-    assert obj.to_json() == {'F1': 42}
+    assert obj.to_json() == {"F1": 42}
 
     assert OptionalStuff.from_json({}).f1 is None
-    assert OptionalStuff.from_json({'F1': 42}).f1 == 42
+    assert OptionalStuff.from_json({"F1": 42}).f1 == 42
 
 
 def test_nonoptional_field():
@@ -244,18 +231,20 @@ def test_nonoptional_field():
 
 
 def test_optional_list():
-    with pytest.raises(TypeError,
-                       match=r"f: Optional\[\] cannot be used for collection fields"):
+    with pytest.raises(TypeError, match=r"f: Optional\[\] cannot be used for collection fields"):
+
         class A(BaseModel):
             f: Optional[List[int]]
 
 
 def test_unexpected_types():
     with pytest.raises(TypeError, match=r"Only Dict\[str\] is supported"):
+
         class A(BaseModel):
             f: Dict[int, int]
 
     with pytest.raises(TypeError, match=r"Unsupported type"):
+
         class B(BaseModel):
             f: set
 
@@ -266,7 +255,7 @@ def test_class_from_json():
 
         @classmethod
         def class_from_json(cls, data):
-            if 'F2' in data:
+            if "F2" in data:
                 return DerivedClassStuff
             else:
                 return BaseClassStuff
@@ -296,7 +285,7 @@ def test_class_from_json_check_current():
 
         @classmethod
         def check_json_current(cls, data):
-            return 'F1' in data and isinstance(data['F1'], str)
+            return "F1" in data and isinstance(data["F1"], str)
 
     assert Stuff.from_json_text('{"F1": 1}', check_current=True) is None
     new_obj = Stuff.from_json_text('{"F1": "foo"}', check_current=True)

--- a/tests/test_koji_query.py
+++ b/tests/test_koji_query.py
@@ -1,7 +1,7 @@
+from textwrap import dedent
 import copy
 import json
 import logging
-from textwrap import dedent
 import time
 
 from pytest import fixture, raises
@@ -13,7 +13,7 @@ from flatpak_indexer.koji_query import (
     query_module_build,
     query_tag_builds,
     refresh_flatpak_builds,
-    refresh_tag_builds
+    refresh_tag_builds,
 )
 from flatpak_indexer.koji_utils import KojiConfig
 from flatpak_indexer.models import FlatpakBuildModel
@@ -29,10 +29,12 @@ class TestConfig(KojiConfig, RedisConfig):
 
 @fixture
 def session():
-    config = TestConfig.from_str(dedent("""
+    config = TestConfig.from_str(
+        dedent("""
         koji_config: fedora
         redis_url: redis://localhost
-"""))
+""")
+    )
     yield Session(config)
 
 
@@ -46,62 +48,64 @@ def test_query_builds(session, caplog):
 
     # First try, we query from scratch from Koji
     caplog.clear()
-    refresh_flatpak_builds(session, ['eog'])
+    refresh_flatpak_builds(session, ["eog"])
     assert "Calling koji.listBuilds({'type': 'image', 'state': 1, 'packageID': 303})" in caplog.text
 
-    builds = list_flatpak_builds(session, 'eog')
+    builds = list_flatpak_builds(session, "eog")
     sort_builds(builds)
     assert len(builds) == 6
-    assert builds[0].nvr == 'eog-stable-3520211004195602.1'
-    assert builds[0].user_name == 'kalev'
-    assert builds[0].completion_time.strftime("%Y-%m-%d %H:%M:%S") == '2021-10-04 23:13:09'
+    assert builds[0].nvr == "eog-stable-3520211004195602.1"
+    assert builds[0].user_name == "kalev"
+    assert builds[0].completion_time.strftime("%Y-%m-%d %H:%M:%S") == "2021-10-04 23:13:09"
 
     # Add quadrapassel to the set we request
     caplog.clear()
-    refresh_flatpak_builds(session, ['eog', 'quadrapassel'])
-    assert ("Calling koji.listBuilds({'type': 'image', 'state': 1, 'packageID': 303})"
-            not in caplog.text)
+    refresh_flatpak_builds(session, ["eog", "quadrapassel"])
+    assert (
+        "Calling koji.listBuilds({'type': 'image', 'state': 1, 'packageID': 303})"
+        not in caplog.text
+    )
 
-    new_builds = list_flatpak_builds(session, 'eog')
+    new_builds = list_flatpak_builds(session, "eog")
     sort_builds(new_builds)
     assert len(new_builds) == 6
 
-    new_builds = list_flatpak_builds(session, 'quadrapassel')
+    new_builds = list_flatpak_builds(session, "quadrapassel")
     assert len(new_builds) == 1
-    assert new_builds[0].nvr == 'quadrapassel-stable-3520211005192946.1'
+    assert new_builds[0].nvr == "quadrapassel-stable-3520211005192946.1"
 
 
 @mock_koji
 @mock_redis
 def test_query_builds_refresh(session):
-    EOG_NVR = 'eog-stable-3520211004195602.1'
-    QUADRAPASSEL_NVR = 'quadrapassel-stable-3520211005192946.1'
+    EOG_NVR = "eog-stable-3520211004195602.1"
+    QUADRAPASSEL_NVR = "quadrapassel-stable-3520211005192946.1"
 
     def filter_build_1(build):
-        if build['nvr'] in (EOG_NVR, QUADRAPASSEL_NVR):
+        if build["nvr"] in (EOG_NVR, QUADRAPASSEL_NVR):
             return None
 
         return build
 
     session.koji_session = make_koji_session(filter_build=filter_build_1)
-    refresh_flatpak_builds(session, ['eog'])
+    refresh_flatpak_builds(session, ["eog"])
 
-    builds = list_flatpak_builds(session, 'eog')
+    builds = list_flatpak_builds(session, "eog")
     assert len(builds) == 5
 
     current_ts = time.time()
 
     def filter_build_2(build):
-        if build['nvr'] in (EOG_NVR, QUADRAPASSEL_NVR):
+        if build["nvr"] in (EOG_NVR, QUADRAPASSEL_NVR):
             build = copy.copy(build)
-            build['completion_ts'] = current_ts
+            build["completion_ts"] = current_ts
 
         return build
 
     session.koji_session = make_koji_session(filter_build=filter_build_2)
-    refresh_flatpak_builds(session, ['eog'])
+    refresh_flatpak_builds(session, ["eog"])
 
-    builds = list_flatpak_builds(session, 'eog')
+    builds = list_flatpak_builds(session, "eog")
     assert len(builds) == 6
 
 
@@ -114,24 +118,24 @@ def test_query_builds_refetch(session, caplog):
         builds.sort(key=lambda x: x.build_id)
 
     # query from scratch from Koji to prime the redis cache
-    refresh_flatpak_builds(session, ['eog'])
+    refresh_flatpak_builds(session, ["eog"])
     assert "Calling koji.listBuilds({'type': 'image', 'state': 1, 'packageID': 303})" in caplog.text
 
-    builds = list_flatpak_builds(session, 'eog')
+    builds = list_flatpak_builds(session, "eog")
     sort_builds(builds)
     assert len(builds) == 6
 
     # Now we simulate having old schemas and missing data
-    raw = session.redis_client.get('build:' + builds[0].nvr)
+    raw = session.redis_client.get("build:" + builds[0].nvr)
     assert raw
     data = json.loads(raw)
     data["PackageBuilds"] = [pb["Nvr"] for pb in data["PackageBuilds"]]
-    session.redis_client.set('build:' + builds[0].nvr, json.dumps(data))
+    session.redis_client.set("build:" + builds[0].nvr, json.dumps(data))
 
-    session.redis_client.delete('build:' + builds[1].nvr)
+    session.redis_client.delete("build:" + builds[1].nvr)
 
     caplog.clear()
-    new_builds = list_flatpak_builds(session, 'eog')
+    new_builds = list_flatpak_builds(session, "eog")
 
     sort_builds(new_builds)
     assert len(new_builds) == 6
@@ -148,25 +152,25 @@ def test_query_image_build(session, caplog):
     caplog.set_level(logging.INFO)
 
     caplog.clear()
-    build = query_image_build(session, 'baobab-stable-3620220517102805.1')
+    build = query_image_build(session, "baobab-stable-3620220517102805.1")
     assert "Calling koji.getBuild" in caplog.text
 
     assert isinstance(build, FlatpakBuildModel)
 
-    assert build.nvr == 'baobab-stable-3620220517102805.1'
-    assert build.repository == 'baobab'
+    assert build.nvr == "baobab-stable-3620220517102805.1"
+    assert build.repository == "baobab"
 
     assert len(build.images) == 2
-    image = [i for i in build.images if i.architecture == 'amd64'][0]
-    assert image.digest == 'sha256:6cca1bdcabf459f3510ccd6a4d196e5a9bde7e049468d2abdb5a404d67ad028c'
-    assert image.media_type == 'application/vnd.oci.image.manifest.v1+json'
-    assert image.labels['org.flatpak.ref'] == 'app/org.gnome.baobab/x86_64/stable'
+    image = [i for i in build.images if i.architecture == "amd64"][0]
+    assert image.digest == "sha256:6cca1bdcabf459f3510ccd6a4d196e5a9bde7e049468d2abdb5a404d67ad028c"
+    assert image.media_type == "application/vnd.oci.image.manifest.v1+json"
+    assert image.labels["org.flatpak.ref"] == "app/org.gnome.baobab/x86_64/stable"
     assert image.diff_ids == [
-        'sha256:c9e7b6727e409ad4648854bf4922b1760a3cc8de32b17b28a802b6bea9c2d2da'
+        "sha256:c9e7b6727e409ad4648854bf4922b1760a3cc8de32b17b28a802b6bea9c2d2da"
     ]
 
     caplog.clear()
-    build2 = query_image_build(session, 'baobab-stable-3620220517102805.1')
+    build2 = query_image_build(session, "baobab-stable-3620220517102805.1")
     assert "Calling koji.getBuild" not in caplog.text
 
     assert isinstance(build2, FlatpakBuildModel)
@@ -175,16 +179,16 @@ def test_query_image_build(session, caplog):
 @mock_koji
 @mock_redis
 def test_query_image_build_package_builds(session, caplog):
-    build = query_image_build(session, 'eog-stable-3620220905044417.1')
+    build = query_image_build(session, "eog-stable-3620220905044417.1")
     assert isinstance(build, FlatpakBuildModel)
     assert [pb.nvr.name for pb in build.package_builds] == [
-        'eog',
-        'exempi',
-        'gnome-desktop3',
-        'libpeas',
-        'libpeas-gtk',
-        'libportal',
-        'libportal-gtk3',
+        "eog",
+        "exempi",
+        "gnome-desktop3",
+        "libpeas",
+        "libpeas-gtk",
+        "libportal",
+        "libportal-gtk3",
     ]
 
 
@@ -194,12 +198,12 @@ def test_query_image_build_no_images(session):
     def filter_archives(build, archives):
         archives = copy.deepcopy(archives)
         for a in archives:
-            a['extra'].pop('docker', None)
+            a["extra"].pop("docker", None)
 
         return archives
 
     session.koji_session = make_koji_session(filter_archives=filter_archives)
-    build = query_image_build(session, 'baobab-stable-3620220517102805.1')
+    build = query_image_build(session, "baobab-stable-3620220517102805.1")
     assert build.images == []
 
 
@@ -209,14 +213,14 @@ def test_query_image_build_missing_digest(session):
     def filter_archives(build, archives):
         archives = copy.deepcopy(archives)
         for a in archives:
-            a['extra']['docker']['digests'] = {}
+            a["extra"]["docker"]["digests"] = {}
 
         return archives
 
     session.koji_session = make_koji_session(filter_archives=filter_archives)
 
     with raises(RuntimeError, match=r"Can't find OCI or docker digest in image"):
-        query_image_build(session, 'baobab-stable-3620220517102805.1')
+        query_image_build(session, "baobab-stable-3620220517102805.1")
 
 
 @mock_koji
@@ -226,26 +230,26 @@ def test_query_module_build(session, caplog):
 
     # Try with a context
     caplog.clear()
-    build = query_module_build(session, 'eog-stable-3620220905044417.ff2200aa')
-    assert build.nvr == 'eog-stable-3620220905044417.ff2200aa'
+    build = query_module_build(session, "eog-stable-3620220905044417.ff2200aa")
+    assert build.nvr == "eog-stable-3620220905044417.ff2200aa"
     assert "Calling koji.getBuild" in caplog.text
 
     caplog.clear()
-    build = query_module_build(session, 'eog-stable-3620220905044417.ff2200aa')
-    assert build.nvr == 'eog-stable-3620220905044417.ff2200aa'
+    build = query_module_build(session, "eog-stable-3620220905044417.ff2200aa")
+    assert build.nvr == "eog-stable-3620220905044417.ff2200aa"
     assert "Calling koji.getBuild" not in caplog.text
 
     # And without a context (again from scratch)
     session.redis_client = make_redis_client()
 
     caplog.clear()
-    build = query_module_build(session, 'eog-stable-3620220905044417')
+    build = query_module_build(session, "eog-stable-3620220905044417")
     assert "Calling koji.getPackageID" in caplog.text
     assert "Calling koji.listBuilds" in caplog.text
 
     caplog.clear()
-    build = query_module_build(session, 'eog-stable-3620220905044417')
-    assert build.nvr == 'eog-stable-3620220905044417.ff2200aa'
+    build = query_module_build(session, "eog-stable-3620220905044417")
+    assert build.nvr == "eog-stable-3620220905044417.ff2200aa"
     assert "Calling koji.getPackageID" not in caplog.text
     assert "Calling koji.listBuilds" not in caplog.text
 
@@ -253,31 +257,31 @@ def test_query_module_build(session, caplog):
 @mock_koji
 @mock_redis
 def test_query_module_build_package_builds(session, caplog):
-    build = query_module_build(session, 'eog-stable-3620220905044417.ff2200aa')
+    build = query_module_build(session, "eog-stable-3620220905044417.ff2200aa")
     assert [pb.nvr.name for pb in build.package_builds] == [
-        'eog',
-        'eog-debuginfo',
-        'eog-debugsource',
-        'eog-devel',
-        'eog-tests',
-        'exempi',
-        'exempi-debuginfo',
-        'exempi-debugsource',
-        'exempi-devel',
-        'libportal',
-        'libportal-debuginfo',
-        'libportal-debugsource',
-        'libportal-devel',
-        'libportal-devel-doc',
-        'libportal-gtk3',
-        'libportal-gtk3-debuginfo',
-        'libportal-gtk3-devel',
-        'libportal-gtk4',
-        'libportal-gtk4-debuginfo',
-        'libportal-gtk4-devel',
-        'libportal-qt5',
-        'libportal-qt5-debuginfo',
-        'libportal-qt5-devel',
+        "eog",
+        "eog-debuginfo",
+        "eog-debugsource",
+        "eog-devel",
+        "eog-tests",
+        "exempi",
+        "exempi-debuginfo",
+        "exempi-debugsource",
+        "exempi-devel",
+        "libportal",
+        "libportal-debuginfo",
+        "libportal-debugsource",
+        "libportal-devel",
+        "libportal-devel-doc",
+        "libportal-gtk3",
+        "libportal-gtk3-debuginfo",
+        "libportal-gtk3-devel",
+        "libportal-gtk4",
+        "libportal-gtk4-debuginfo",
+        "libportal-gtk4-devel",
+        "libportal-qt5",
+        "libportal-qt5-debuginfo",
+        "libportal-qt5-devel",
     ]
 
 
@@ -285,8 +289,8 @@ def test_query_module_build_package_builds(session, caplog):
 @mock_redis
 def test_query_module_build_multiple_contexts(session, caplog):
     caplog.clear()
-    build = query_module_build(session, 'django-1.6-20180828135711')
-    assert build.nvr == 'django-1.6-20180828135711.a5b0195c'
+    build = query_module_build(session, "django-1.6-20180828135711")
+    assert build.nvr == "django-1.6-20180828135711.a5b0195c"
     assert "More than one context for django-1.6-20180828135711, using most recent!" in caplog.text
 
 
@@ -301,24 +305,24 @@ def test_query_package_build_by_bad_id(session):
 @mock_redis
 def test_query_build_missing(session):
     with raises(RuntimeError, match="Could not look up BAH-1-1 in Koji"):
-        query_image_build(session, 'BAH-1-1')
+        query_image_build(session, "BAH-1-1")
 
     with raises(RuntimeError, match="Could not look up package ID for BAH"):
-        query_module_build(session, 'BAH-1-1')
+        query_module_build(session, "BAH-1-1")
 
     with raises(RuntimeError, match="Could not look up eog-1-1 in Koji"):
-        query_module_build(session, 'eog-1-1')
+        query_module_build(session, "eog-1-1")
 
 
 @mock_koji
 @mock_redis
 def test_query_tag_builds(session):
-    refresh_tag_builds(session, 'f36')
-    build_names = sorted(query_tag_builds(session, 'f36', 'quadrapassel'))
+    refresh_tag_builds(session, "f36")
+    build_names = sorted(query_tag_builds(session, "f36", "quadrapassel"))
 
     assert build_names == [
-        'quadrapassel-40.2-2.fc35',
-        'quadrapassel-40.2-3.fc36',
+        "quadrapassel-40.2-2.fc35",
+        "quadrapassel-40.2-3.fc36",
     ]
 
 
@@ -329,25 +333,25 @@ def test_query_tag_builds_incremental(session):
     # mid-way through the f28 development cycle
     session.koji_session = make_koji_session(tag_query_timestamp=1643846400)
 
-    refresh_tag_builds(session, 'f36')
+    refresh_tag_builds(session, "f36")
 
-    build_names = sorted(query_tag_builds(session, 'f36', 'gnome-desktop3'))
+    build_names = sorted(query_tag_builds(session, "f36", "gnome-desktop3"))
     assert build_names == [
-        'gnome-desktop3-41.3-1.fc36',
-        'gnome-desktop3-42~alpha.1-1.fc36',
-        'gnome-desktop3-42~alpha.1-2.fc36',
-        'gnome-desktop3-42~alpha.1-3.fc36',
+        "gnome-desktop3-41.3-1.fc36",
+        "gnome-desktop3-42~alpha.1-1.fc36",
+        "gnome-desktop3-42~alpha.1-2.fc36",
+        "gnome-desktop3-42~alpha.1-3.fc36",
     ]
 
     # Now switch to a koji session without that limitation,
     # check that when we refresh, we add and remove builds properly
     session.koji_session = make_koji_session()
 
-    refresh_tag_builds(session, 'f36')
+    refresh_tag_builds(session, "f36")
 
-    build_names = sorted(query_tag_builds(session, 'f36', 'gnome-desktop3'))
+    build_names = sorted(query_tag_builds(session, "f36", "gnome-desktop3"))
     assert build_names == [
-        'gnome-desktop3-42~alpha.1-3.fc36',
-        'gnome-desktop3-42~beta-3.fc36',
-        'gnome-desktop3-42.0-1.fc36',
+        "gnome-desktop3-42~alpha.1-3.fc36",
+        "gnome-desktop3-42~beta-3.fc36",
+        "gnome-desktop3-42.0-1.fc36",
     ]

--- a/tests/test_koji_updater.py
+++ b/tests/test_koji_updater.py
@@ -7,6 +7,7 @@ import yaml
 from flatpak_indexer.datasource.koji import KojiUpdater
 from flatpak_indexer.models import RegistryModel
 from flatpak_indexer.test.redis import mock_redis
+
 from .pyxis import mock_pyxis
 from .utils import get_config, mock_brew, mock_odcs
 
@@ -61,22 +62,27 @@ indexes:
 def test_pyxis_updater_koji(tmp_path, inherit):
     cfg = deepcopy(KOJI_CONFIG)
     if inherit:
-        cfg['indexes']['brew-rc']['koji_tags'] = ['release-candidate-3+']
+        cfg["indexes"]["brew-rc"]["koji_tags"] = ["release-candidate-3+"]
 
     config = get_config(tmp_path, cfg)
 
     updater = KojiUpdater(config)
 
     registry_data = run_update(updater)
-    data = registry_data['brew']
+    data = registry_data["brew"]
 
     assert len(data.repositories) == 1
-    aisleriot_repository = data.repositories['rh-osbs/aisleriot']
-    assert aisleriot_repository.name == 'rh-osbs/aisleriot'
+    aisleriot_repository = data.repositories["rh-osbs/aisleriot"]
+    assert aisleriot_repository.name == "rh-osbs/aisleriot"
     assert len(aisleriot_repository.images) == 1
     aisleriot_image = next(iter(aisleriot_repository.images.values()))
-    assert aisleriot_image.digest == \
-        'sha256:fade1e55c4d226da18ec4a6386263d8b2125fc874c8b4f4f97b31593037ea0bb'
+    assert (
+        aisleriot_image.digest
+        == "sha256:fade1e55c4d226da18ec4a6386263d8b2125fc874c8b4f4f97b31593037ea0bb"
+    )
     assert aisleriot_image.tags == [
-        'el8', 'el8-8020020200121102609.2', 'release-candidate', 'release-candidate-2'
+        "el8",
+        "el8-8020020200121102609.2",
+        "release-candidate",
+        "release-candidate-2",
     ]

--- a/tests/test_koji_utils.py
+++ b/tests/test_koji_utils.py
@@ -1,6 +1,5 @@
-from flatpak_indexer.koji_utils import get_koji_session, KojiConfig
+from flatpak_indexer.koji_utils import KojiConfig, get_koji_session
 from flatpak_indexer.test.koji import mock_koji
-
 
 CONFIG = """
 koji_config: fedora

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,11 +1,6 @@
 from copy import deepcopy
 
-from flatpak_indexer.models import (
-    FlatpakBuildModel,
-    ImageBuildModel,
-    ImageModel,
-    RegistryModel
-)
+from flatpak_indexer.models import FlatpakBuildModel, ImageBuildModel, ImageModel, RegistryModel
 
 IMAGE1 = {
     "Annotations": {"key1": "value1"},
@@ -14,12 +9,12 @@ IMAGE1 = {
     "Labels": {
         "com.redhat.component": "baobob",
         "version": "master",
-        "release": "3220200331145937.2"
+        "release": "3220200331145937.2",
     },
     "MediaType": "application/vnd.docker.distribution.manifest.v2+json",
     "OS": "linux",
     "Tags": ["tag1"],
-    'PullSpec': 'candidate-registry.fedoraproject.org/baobab@sha256:12345'
+    "PullSpec": "candidate-registry.fedoraproject.org/baobab@sha256:12345",
 }
 
 IMAGE2 = {
@@ -29,7 +24,7 @@ IMAGE2 = {
     "Labels": {"key2": "value2"},
     "MediaType": "application/vnd.docker.distribution.manifest.v2+json",
     "OS": "linux",
-    "Tags": ["tag2"]
+    "Tags": ["tag2"],
 }
 
 LIST1 = {
@@ -47,31 +42,29 @@ REGISTRY = {
                 IMAGE1,
                 IMAGE2,
             ],
-            "Lists": [
-                LIST1
-            ],
+            "Lists": [LIST1],
         }
     ]
 }
 
 IMAGE_BUILD = {
-    'BuildId': 12345,
-    'Nvr': 'testrepo-1.2.3-1',
-    'Source': 'git://src.fedoraproject.org/flatpaks/baobab#BAOBAB_GIT_DIGEST',
-    'CompletionTime': '2020-07-31T16:26:22+00:00',
-    'UserName': 'jdoe',
-    'Images': [IMAGE1]
+    "BuildId": 12345,
+    "Nvr": "testrepo-1.2.3-1",
+    "Source": "git://src.fedoraproject.org/flatpaks/baobab#BAOBAB_GIT_DIGEST",
+    "CompletionTime": "2020-07-31T16:26:22+00:00",
+    "UserName": "jdoe",
+    "Images": [IMAGE1],
 }
 
 FLATPAK_BUILD = {
-    'BuildId': 12345,
-    'Nvr': 'testrepo-1.2.3-1',
-    'Source': 'git://src.fedoraproject.org/flatpaks/baobab#BAOBAB_GIT_DIGEST',
-    'CompletionTime': '2020-07-31T16:26:22+00:00',
-    'UserName': 'jdoe',
-    'Images': [IMAGE1],
-    'ModuleBuilds': ['baobab-1.2.3-3020190603102507'],
-    'PackageBuilds': [{'Nvr': 'baobab-1.2.3-1', 'SourceNvr': 'baobab-1.2.3-1'}],
+    "BuildId": 12345,
+    "Nvr": "testrepo-1.2.3-1",
+    "Source": "git://src.fedoraproject.org/flatpaks/baobab#BAOBAB_GIT_DIGEST",
+    "CompletionTime": "2020-07-31T16:26:22+00:00",
+    "UserName": "jdoe",
+    "Images": [IMAGE1],
+    "ModuleBuilds": ["baobab-1.2.3-3020190603102507"],
+    "PackageBuilds": [{"Nvr": "baobab-1.2.3-1", "SourceNvr": "baobab-1.2.3-1"}],
 }
 
 
@@ -86,15 +79,15 @@ def test_registry_model_add_image():
     model = RegistryModel.from_json(REGISTRY)
 
     image = ImageModel.from_json(IMAGE1)
-    model.add_image('aisleriot2', image)
+    model.add_image("aisleriot2", image)
 
-    assert model.repositories['aisleriot2'].images[image.digest] == image
+    assert model.repositories["aisleriot2"].images[image.digest] == image
 
 
 def test_image_nvr():
     image = ImageModel.from_json(IMAGE1)
 
-    assert image.nvr == 'baobob-master-3220200331145937.2'
+    assert image.nvr == "baobob-master-3220200331145937.2"
 
     image.labels = {}
     assert image.nvr is None
@@ -109,7 +102,7 @@ def test_image_nvr_no_koji():
 
 def test_image_build_repository():
     image = ImageBuildModel.from_json(IMAGE_BUILD)
-    assert image.repository == 'baobab'
+    assert image.repository == "baobab"
 
 
 def test_image_build_from_json():

--- a/tests/test_odcs_query.py
+++ b/tests/test_odcs_query.py
@@ -1,5 +1,6 @@
-from flatpak_indexer.odcs_query import composes_to_modules, OdcsConfig
+from flatpak_indexer.odcs_query import OdcsConfig, composes_to_modules
 from flatpak_indexer.session import Session
+
 from .utils import mock_odcs
 
 
@@ -9,4 +10,4 @@ def test_composes_to_modules():
     session = Session(config)
 
     modules = composes_to_modules(session, [12345, 34567])
-    assert modules == ['aisleriot:el8:8020020200121102609:73699f59']
+    assert modules == ["aisleriot:el8:8020020200121102609:73699f59"]

--- a/tests/test_registry_query.py
+++ b/tests/test_registry_query.py
@@ -1,5 +1,5 @@
-import logging
 from textwrap import dedent
+import logging
 
 from pytest import fixture
 
@@ -8,35 +8,36 @@ from flatpak_indexer.registry_client import RegistryClient
 from flatpak_indexer.registry_query import query_registry_image
 from flatpak_indexer.session import Session
 from flatpak_indexer.test.redis import mock_redis
-from .registry import mock_registry, MockRegistry
+
+from .registry import MockRegistry, mock_registry
 
 
 @fixture
 def session():
-    config = RedisConfig.from_str(dedent("""
+    config = RedisConfig.from_str(
+        dedent("""
         redis_url: redis://localhost
-"""))
+""")
+    )
     yield Session(config)
 
 
 @mock_registry
 @mock_redis
 def test_query_registry_image(session, registry_mock: MockRegistry, caplog):
-    manifest_digest, _ = registry_mock.add_fake_image('repo1', 'latest', labels={
-        "org.flatpak.ref": "app/com.example.MyProg/x86_64/stable"
-    })
+    manifest_digest, _ = registry_mock.add_fake_image(
+        "repo1", "latest", labels={"org.flatpak.ref": "app/com.example.MyProg/x86_64/stable"}
+    )
     caplog.set_level(logging.INFO)
-    registry_client = RegistryClient('https://registry.example.com')
+    registry_client = RegistryClient("https://registry.example.com")
 
-    image = query_registry_image(session, registry_client, 'repo1', manifest_digest,
-                                 'fake image')
+    image = query_registry_image(session, registry_client, "repo1", manifest_digest, "fake image")
     assert image.digest == manifest_digest
 
     assert "Fetching manifest and config for fake image" in caplog.text
     caplog.clear()
 
     # Try again, make sure cached in redis
-    image = query_registry_image(session, registry_client, 'repo1', manifest_digest,
-                                 'fake image')
+    image = query_registry_image(session, registry_client, "repo1", manifest_digest, "fake image")
     assert image.digest == manifest_digest
     assert "Fetching manifest and config for fake image" not in caplog.text

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,13 +1,13 @@
 from contextlib import contextmanager
 from functools import wraps
-import json
-import os
-import re
-import subprocess
 from tempfile import NamedTemporaryFile
 from typing import Any, Dict, List
 from unittest.mock import DEFAULT, MagicMock, patch
 from urllib.parse import urlparse
+import json
+import os
+import re
+import subprocess
 
 import responses
 import yaml
@@ -16,8 +16,9 @@ from flatpak_indexer.config import Config
 
 
 def write_config(tmp_path, content):
-    tmpfile = NamedTemporaryFile(delete=False, prefix="config-", suffix=".yaml", dir=tmp_path,
-                                 encoding="UTF-8", mode="w")
+    tmpfile = NamedTemporaryFile(
+        delete=False, prefix="config-", suffix=".yaml", dir=tmp_path, encoding="UTF-8", mode="w"
+    )
     yaml.dump(content, tmpfile)
     tmpfile.close()
     return tmpfile.name
@@ -33,26 +34,25 @@ def get_config(tmp_path, content):
 def setup_client_cert(tmp_path, create_cert=True, create_key=True):
     cert_path = str(tmp_path / "client.crt")
     if create_cert:
-        with open(cert_path, 'w'):
+        with open(cert_path, "w"):
             pass
 
     key_path = str(tmp_path / "client.key")
     if create_key:
-        with open(key_path, 'w'):
+        with open(key_path, "w"):
             pass
 
     return cert_path, key_path
 
 
-_TEST_ICON_DATA = \
-    """iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAIAAAAlC+aJAAABeklEQVRo3t3ay3KEMAxEUdH//8/O
+_TEST_ICON_DATA = """iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAIAAAAlC+aJAAABeklEQVRo3t3ay3KEMAxEUdH//8/O
     JplMgDGy3JLb8YqCBfdQPAqXD/sZrTXbZxzH8b3xvncXw6v+DNjC8F5vZjgVnw6L17fWcL3qsoZr
     vZnh9s4RNNzW/wLEDZ/q/wBkDZ36M0DQ0K+/AUgZHuvvASIGT/1HwHKDs74HWGjw1z8AlhiG6p8B
     xYbRehegzBCo9wIKDLH6AUCqIVw/BkgyzNQPA+iGyfoIgGiYrw8CKAZKfRwwaWDVTwHCBmL9LCBg
     4NYTAEMGej0H4DRk1NMAj4akeiagY8irN7ODPpfYf47pp4OxRycxY+KVD/gUmjRtnAKoHCkAz2tU
     F+D/kCkCrm/M7H9RpNYX/E8juz7bgIL6VANq6vMMKKtPMqCyPsOA4nq6AfX1XAOW1BMNWFXPMmBh
     PcWAtfXzBiyvnzRAoX7GAJH6sAE69TEDpOoDBqjVjxogWD9kgGa93wDZeqcByvUeA8TrHw3Qr+8b
-    sEV9x7D90uN/tPh70+X3X82aXIZ8Z5vMAAAAAElFTkSuQmCC""".replace('\n', '')
+    sEV9x7D90uN/tPh70+X3X82aXIZ8Z5vMAAAAAElFTkSuQmCC""".replace("\n", "")
 
 _AISLERIOT_LABELS = {
     "org.flatpak.ref": "app/org.gnome.Aisleriot/x86_64/stable",
@@ -72,462 +72,442 @@ _AISLERIOT2_LABELS = {
 
 _KOJI_BUILDS: List[Dict[str, Any]] = [
     {
-        'build_id': 1063042,
-        'completion_ts': 1598464962.42521,
-        'extra': {
-            'image': {
-                'flatpak': True,
-                'index': {
-                    'digests': {'application/vnd.docker.distribution.manifest.list.v2+json':
-                                'sha256:' +
-                                '9849e17af5db2f38650970c2ce0f2897b6e552e5b7e67adfb53ab51243b5f5f5'},
-
-                    'floating_tags': ['latest', 'el8'],
-                    'pull': [
-                        'registry-proxy.engineering.redhat.com/rh-osbs/aisleriot@' +
-                        'sha256:9849e17af5db2f38650970c2ce0f2897b6e552e5b7e67adfb53ab51243b5f5f5',
-                        'registry-proxy.engineering.redhat.com/rh-osbs/aisleriot:' +
-                        'el8-8020020200121102609.1'],
-                    'tags': ['el8-8020020200121102609.1'],
+        "build_id": 1063042,
+        "completion_ts": 1598464962.42521,
+        "extra": {
+            "image": {
+                "flatpak": True,
+                "index": {
+                    "digests": {
+                        "application/vnd.docker.distribution.manifest.list.v2+json": "sha256:"
+                        + "9849e17af5db2f38650970c2ce0f2897b6e552e5b7e67adfb53ab51243b5f5f5"
+                    },
+                    "floating_tags": ["latest", "el8"],
+                    "pull": [
+                        "registry-proxy.engineering.redhat.com/rh-osbs/aisleriot@"
+                        + "sha256:9849e17af5db2f38650970c2ce0f2897b6e552e5b7e67adfb53ab51243b5f5f5",
+                        "registry-proxy.engineering.redhat.com/rh-osbs/aisleriot:"
+                        + "el8-8020020200121102609.1",
+                    ],
+                    "tags": ["el8-8020020200121102609.1"],
                 },
-                'modules': ['aisleriot-el8-8020020200121102609'],
-                'odcs': {
-                    'compose_ids': [12345, 34567]
-                }
+                "modules": ["aisleriot-el8-8020020200121102609"],
+                "odcs": {"compose_ids": [12345, 34567]},
             }
         },
-        'name': 'aisleriot-container',
-        'nvr': 'aisleriot-container-el8-8020020200121102609.1',
-        'owner_name': 'jdoe',
-        'package_id': 22,
-        'source': 'git://pkgs.devel.redhat.com/containers/aisleriot#AISLERIOT_GIT_DIGEST',
-        '_TYPE': 'image',
-        '_TAGS': ['release-candidate', 'release-candidate-4'],
-        '_ARCHIVES': [
+        "name": "aisleriot-container",
+        "nvr": "aisleriot-container-el8-8020020200121102609.1",
+        "owner_name": "jdoe",
+        "package_id": 22,
+        "source": "git://pkgs.devel.redhat.com/containers/aisleriot#AISLERIOT_GIT_DIGEST",
+        "_TYPE": "image",
+        "_TAGS": ["release-candidate", "release-candidate-4"],
+        "_ARCHIVES": [
             {
-                'btype': 'image',
-                'extra': {
-                    'docker': {
-                        'config': {
-                            'architecture': 'amd64',
-                            'config': {
-                                'Labels': _AISLERIOT_LABELS,
+                "btype": "image",
+                "extra": {
+                    "docker": {
+                        "config": {
+                            "architecture": "amd64",
+                            "config": {
+                                "Labels": _AISLERIOT_LABELS,
                             },
-                            'os': 'linux',
-                            'rootfs': {
-                                'diff_ids': ['sha256:5a1ad']
-                            },
+                            "os": "linux",
+                            "rootfs": {"diff_ids": ["sha256:5a1ad"]},
                         },
-                        'digests': {
-                            'application/vnd.docker.distribution.manifest.v2+json':
-                            'sha256:' +
-                                'bo1dfacec4d226da18ec4a6386263d8b2125fc874c8b4f4f97b31593037ea0bb',
+                        "digests": {
+                            "application/vnd.docker.distribution.manifest.v2+json": "sha256:"
+                            + "bo1dfacec4d226da18ec4a6386263d8b2125fc874c8b4f4f97b31593037ea0bb",
                         },
-                        'repositories': [
-                            'registry-proxy.engineering.redhat/rh-osbs/aisleriot:build-1234-x86_64'
-                        ]
+                        "repositories": [
+                            "registry-proxy.engineering.redhat/rh-osbs/aisleriot:build-1234-x86_64"
+                        ],
                     },
-                    'image': {
-                        'arch': 'x86_64',
-                    }
+                    "image": {
+                        "arch": "x86_64",
+                    },
                 },
-                'id': 15321,
+                "id": 15321,
             },
             {
-                'btype': 'icm',
-                'extra': {'typeinfo': {'icm': {}}},
-                'id': 8014375,
-            },
-        ]
-    },
-    {
-        'build_id': 1063052,
-        'completion_ts': 1598465962.42521,
-        'extra': {
-            'image': {
-                'flatpak': True,
-                'index': {
-                    'digests': {'application/vnd.docker.distribution.manifest.list.v2+json':
-                                'sha256:' +
-                                'b0b51edaf5db2f38650970c2ce0f2897b6e552e5b7e67adfb53ab51243b5f5f5'},
-
-                    'floating_tags': ['latest', 'el8'],
-                    'pull': [
-                        'registry-proxy.engineering.redhat.com/rh-osbs/aisleriot@' +
-                        'sha256:b0b51edaf5db2f38650970c2ce0f2897b6e552e5b7e67adfb53ab51243b5f5f5',
-                        'registry-proxy.engineering.redhat.com/rh-osbs/aisleriot:' +
-                        'el8-8020020200121102609.1'],
-                    'tags': ['el8-8020020200121102609.1'],
-                },
-                'modules': ['aisleriot-el8-8020020200121102609'],
-            }
-        },
-        'name': 'aisleriot-container',
-        'nvr': 'aisleriot-container-el8-8020020200121102609.2',
-        'owner_name': 'jdoe',
-        'package_id': 22,
-        'source': 'git://pkgs.devel.redhat.com/containers/aisleriot#AISLERIOT_GIT_DIGEST',
-        '_TYPE': 'image',
-        '_TAGS': ['release-candidate-2'],
-        '_ARCHIVES': [
-            {
-                'btype': 'image',
-                'extra': {
-                    'docker': {
-                        'config': {
-                            'architecture': 'amd64',
-                            'config': {
-                                'Labels': _AISLERIOT_LABELS,
-                            },
-                            'os': 'linux',
-                            'rootfs': {
-                                'diff_ids': ['sha256:5a1ad']
-                            },
-                        },
-                        'digests': {
-                            'application/vnd.docker.distribution.manifest.v2+json':
-                            'sha256:' +
-                                'fade1e55c4d226da18ec4a6386263d8b2125fc874c8b4f4f97b31593037ea0bb',
-                        },
-                        'repositories': [
-                            'registry-proxy.engineering.redhat/rh-osbs/aisleriot:build-1235-x86_64'
-                        ]
-                    },
-                    'image': {
-                        'arch': 'x86_64',
-                    }
-                },
-                'id': 15322,
-            }
-        ]
-    },
-    {
-        'build_id': 54321,
-        'completion_ts': 1598464000.,
-        'extra': {
-            'typeinfo': {
-                'module': {
-                    'modulemd_str': 'xxxxx',
-                },
-            }
-        },
-        'name': 'aisleriot',
-        'nvr': 'aisleriot-el8-8020020200121102609.73699f59',
-        'owner_name': 'jdoe',
-        'source': 'git://pkgs.devel.redhat.com/modules/aisleriot#AISLERIOT_MODULE_DIGEST',
-        'package_id': 21,
-        '_TYPE': 'module',
-        '_TAGS': [],
-        '_ARCHIVES': [
-            {
-                'filename': 'modulemd.txt',
-                'id': 1001,
+                "btype": "icm",
+                "extra": {"typeinfo": {"icm": {}}},
+                "id": 8014375,
             },
         ],
     },
     {
-        'build_id': 1063043,
-        'completion_ts': 1598465000.0,
-        'extra': {
-            'image': {
-                'flatpak': True,
-                'index': {
-                    'digests': {'application/vnd.docker.distribution.manifest.list.v2+json':
-                                'sha256:' +
-                                'AISLERIOT2_DIGEST'},
-
-                    'floating_tags': ['latest', 'el8'],
-                    'pull': [
-                        'registry-proxy.engineering.redhat.com/rh-osbs/aisleriot2@' +
-                        'sha256:AISLERIOT2_DIGEST',
-                        'registry-proxy.engineering.redhat.com/rh-osbs/aisleriot2:' +
-                        'el8-8020020200121102609.1'],
-                    'tags': ['el8-8020020200121102609.1'],
+        "build_id": 1063052,
+        "completion_ts": 1598465962.42521,
+        "extra": {
+            "image": {
+                "flatpak": True,
+                "index": {
+                    "digests": {
+                        "application/vnd.docker.distribution.manifest.list.v2+json": "sha256:"
+                        + "b0b51edaf5db2f38650970c2ce0f2897b6e552e5b7e67adfb53ab51243b5f5f5"
+                    },
+                    "floating_tags": ["latest", "el8"],
+                    "pull": [
+                        "registry-proxy.engineering.redhat.com/rh-osbs/aisleriot@"
+                        + "sha256:b0b51edaf5db2f38650970c2ce0f2897b6e552e5b7e67adfb53ab51243b5f5f5",
+                        "registry-proxy.engineering.redhat.com/rh-osbs/aisleriot:"
+                        + "el8-8020020200121102609.1",
+                    ],
+                    "tags": ["el8-8020020200121102609.1"],
                 },
-                'modules': ['aisleriot-el8-8020020200121102609'],
+                "modules": ["aisleriot-el8-8020020200121102609"],
             }
         },
-        'name': 'aisleriot2-container',
-        'nvr': 'aisleriot2-container-el8-8020020200121102609.1',
-        'owner_name': 'jdoe',
-        'package_id': 23,
-        'source': 'git://pkgs.devel.redhat.com/containers/aisleriot2#AISLERIOT2_GIT_DIGEST',
-        '_TYPE': 'image',
-        '_TAGS': [],
-        '_ARCHIVES': [
+        "name": "aisleriot-container",
+        "nvr": "aisleriot-container-el8-8020020200121102609.2",
+        "owner_name": "jdoe",
+        "package_id": 22,
+        "source": "git://pkgs.devel.redhat.com/containers/aisleriot#AISLERIOT_GIT_DIGEST",
+        "_TYPE": "image",
+        "_TAGS": ["release-candidate-2"],
+        "_ARCHIVES": [
             {
-                'btype': 'image',
-                'extra': {
-                    'docker': {
-                        'config': {
-                            'architecture': 'amd64',
-                            'config': {
-                                'Labels': _AISLERIOT2_LABELS,
+                "btype": "image",
+                "extra": {
+                    "docker": {
+                        "config": {
+                            "architecture": "amd64",
+                            "config": {
+                                "Labels": _AISLERIOT_LABELS,
                             },
-                            'os': 'linux',
-                            'rootfs': {
-                                'diff_ids': ['sha256:5a1ad']
-                            },
+                            "os": "linux",
+                            "rootfs": {"diff_ids": ["sha256:5a1ad"]},
                         },
-                        'digests': {
-                            'application/vnd.docker.distribution.manifest.v2+json':
-                            'sha256:' +
-                                '5eaf00d1c4d226da18ec4a6386263d8b2125fc874c8b4f4f97b31593037ea0bb',
+                        "digests": {
+                            "application/vnd.docker.distribution.manifest.v2+json": "sha256:"
+                            + "fade1e55c4d226da18ec4a6386263d8b2125fc874c8b4f4f97b31593037ea0bb",
                         },
-                        'repositories': [
-                            'registry-proxy.engineering.redhat/rh-osbs/aisleriot2:build-3456-x86_64'
-                        ]
+                        "repositories": [
+                            "registry-proxy.engineering.redhat/rh-osbs/aisleriot:build-1235-x86_64"
+                        ],
                     },
-                    'image': {
-                        'arch': 'x86_64',
-                    }
+                    "image": {
+                        "arch": "x86_64",
+                    },
                 },
-                'id': 16321,
+                "id": 15322,
             }
-        ]
+        ],
     },
     {
-        'build_id': 1063045,
-        'completion_ts': 1598465000.0,
-        'extra': {
-            'image': {
-                'flatpak': True,
-                'index': {
-                    'digests': {'application/vnd.docker.distribution.manifest.list.v2+json':
-                                'sha256:' +
-                                'AISLERIOT_EL9_DIGEST'},
-
-                    'floating_tags': ['latest', 'el8'],
-                    'pull': [
-                        'registry-proxy.engineering.redhat.com/rh-osbs/aisleriot3@' +
-                        'sha256:AISLERIOT_EL9_DIGEST',
-                        'registry-proxy.engineering.redhat.com/rh-osbs/aisleriot3:' +
-                        'el9-8020020200121102609.1'],
-                    'tags': ['el8-8020020200121102609.1'],
+        "build_id": 54321,
+        "completion_ts": 1598464000.0,
+        "extra": {
+            "typeinfo": {
+                "module": {
+                    "modulemd_str": "xxxxx",
                 },
-                'modules': ['aisleriot-el8-8020020200121102609'],
             }
         },
-        'name': 'aisleriot-container',
-        'nvr': 'aisleriot-container-el9-9010020220121102609.1',
-        'owner_name': 'jdoe',
-        'package_id': 23,
-        'source': 'git://pkgs.devel.redhat.com/containers/aisleriot#AISLERIOT_EL9_GIT_DIGEST',
-        '_TYPE': 'image',
-        '_TAGS': [],
-        '_ARCHIVES': [
+        "name": "aisleriot",
+        "nvr": "aisleriot-el8-8020020200121102609.73699f59",
+        "owner_name": "jdoe",
+        "source": "git://pkgs.devel.redhat.com/modules/aisleriot#AISLERIOT_MODULE_DIGEST",
+        "package_id": 21,
+        "_TYPE": "module",
+        "_TAGS": [],
+        "_ARCHIVES": [
             {
-                'btype': 'image',
-                'extra': {
-                    'docker': {
-                        'config': {
-                            'architecture': 'amd64',
-                            'config': {
-                                'Labels': _AISLERIOT_EL9_LABELS,
-                            },
-                            'os': 'linux',
-                            'rootfs': {
-                                'diff_ids': ['sha256:5a1ad']
-                            },
-                        },
-                        'digests': {
-                            'application/vnd.docker.distribution.manifest.v2+json':
-                            'sha256:' +
-                                'ba5eba11c4d226da18ec4a6386263d8b2125fc874c8b4f4f97b31593037ea0bb',
-                        },
-                        'repositories': [
-                            'registry-proxy.engineering.redhat/rh-osbs/aisleriot3:build-3456-x86_64'
-                        ]
-                    },
-                    'image': {
-                        'arch': 'x86_64',
-                    }
-                },
-                'id': 18321,
-            }
-        ]
+                "filename": "modulemd.txt",
+                "id": 1001,
+            },
+        ],
     },
     {
-        'build_id': 1063045,
-        'completion_ts': 1598465000.0,
-        'extra': {
-            'image': {
-                'flatpak': True,
-                'index': {
-                    'digests': {'application/vnd.docker.distribution.manifest.list.v2+json':
-                                'sha256:' +
-                                'AISLERIOT_EL9_DIGEST'},
-
-                    'floating_tags': ['latest', 'el8'],
-                    'pull': [
-                        'registry-proxy.engineering.redhat.com/rh-osbs/aisleriot3@' +
-                        'sha256:AISLERIOT_EL9_DIGEST',
-                        'registry-proxy.engineering.redhat.com/rh-osbs/aisleriot3:' +
-                        'el9-8020020200121102609.2'],
-                    'tags': ['el8-8020020200121102609.2'],
+        "build_id": 1063043,
+        "completion_ts": 1598465000.0,
+        "extra": {
+            "image": {
+                "flatpak": True,
+                "index": {
+                    "digests": {
+                        "application/vnd.docker.distribution.manifest.list.v2+json": "sha256:"
+                        + "AISLERIOT2_DIGEST"
+                    },
+                    "floating_tags": ["latest", "el8"],
+                    "pull": [
+                        "registry-proxy.engineering.redhat.com/rh-osbs/aisleriot2@"
+                        + "sha256:AISLERIOT2_DIGEST",
+                        "registry-proxy.engineering.redhat.com/rh-osbs/aisleriot2:"
+                        + "el8-8020020200121102609.1",
+                    ],
+                    "tags": ["el8-8020020200121102609.1"],
                 },
-                'modules': ['aisleriot-el8-8020020200121102609'],
+                "modules": ["aisleriot-el8-8020020200121102609"],
             }
         },
-        'name': 'aisleriot-container',
-        'nvr': 'aisleriot-container-el9-9010020220121102609.2',
-        'owner_name': 'jdoe',
-        'package_id': 23,
-        'source': 'git://pkgs.devel.redhat.com/containers/aisleriot#AISLERIOT_EL9_2_GIT_DIGEST',
-        '_TYPE': 'image',
-        '_TAGS': [],
-        '_ARCHIVES': [
+        "name": "aisleriot2-container",
+        "nvr": "aisleriot2-container-el8-8020020200121102609.1",
+        "owner_name": "jdoe",
+        "package_id": 23,
+        "source": "git://pkgs.devel.redhat.com/containers/aisleriot2#AISLERIOT2_GIT_DIGEST",
+        "_TYPE": "image",
+        "_TAGS": [],
+        "_ARCHIVES": [
             {
-                'btype': 'image',
-                'extra': {
-                    'docker': {
-                        'config': {
-                            'architecture': 'amd64',
-                            'config': {
-                                'Labels': _AISLERIOT_EL9_LABELS,
+                "btype": "image",
+                "extra": {
+                    "docker": {
+                        "config": {
+                            "architecture": "amd64",
+                            "config": {
+                                "Labels": _AISLERIOT2_LABELS,
                             },
-                            'os': 'linux',
-                            'rootfs': {
-                                'diff_ids': ['sha256:5a1ad']
-                            },
+                            "os": "linux",
+                            "rootfs": {"diff_ids": ["sha256:5a1ad"]},
                         },
-                        'digests': {
-                            'application/vnd.docker.distribution.manifest.v2+json':
-                            'sha256:AISLERIOT_EL9_2_MANIFEST_DIGEST',
+                        "digests": {
+                            "application/vnd.docker.distribution.manifest.v2+json": "sha256:"
+                            + "5eaf00d1c4d226da18ec4a6386263d8b2125fc874c8b4f4f97b31593037ea0bb",
                         },
-                        'repositories': [
-                            'registry-proxy.engineering.redhat/rh-osbs/aisleriot3:build-3456-x86_64'
-                        ]
+                        "repositories": [
+                            "registry-proxy.engineering.redhat/rh-osbs/aisleriot2:build-3456-x86_64"
+                        ],
                     },
-                    'image': {
-                        'arch': 'x86_64',
-                    }
+                    "image": {
+                        "arch": "x86_64",
+                    },
                 },
-                'id': 19321,
+                "id": 16321,
             }
-        ]
+        ],
     },
     {
-        'build_id': 1063046,
-        'completion_ts': 1598466000.0,
-        'extra': {
-            'image': {
-                'index': {
-                    'digests': {'application/vnd.docker.distribution.manifest.list.v2+json':
-                                'sha256:TESTREPO_DIGEST'},
-
-                    'floating_tags': ['latest', 'el8'],
-                    'pull': [
-                        'registry-proxy.engineering.redhat.com/rh-osbs/testrepo@' +
-                        'sha256:TESTREPO_DIGEST',
-                        'registry-proxy.engineering.redhat.com/rh-osbs/testrepo:' +
-                        '1.2.3-1'],
-                    'tags': ['1.2.3-1'],
+        "build_id": 1063045,
+        "completion_ts": 1598465000.0,
+        "extra": {
+            "image": {
+                "flatpak": True,
+                "index": {
+                    "digests": {
+                        "application/vnd.docker.distribution.manifest.list.v2+json": "sha256:"
+                        + "AISLERIOT_EL9_DIGEST"
+                    },
+                    "floating_tags": ["latest", "el8"],
+                    "pull": [
+                        "registry-proxy.engineering.redhat.com/rh-osbs/aisleriot3@"
+                        + "sha256:AISLERIOT_EL9_DIGEST",
+                        "registry-proxy.engineering.redhat.com/rh-osbs/aisleriot3:"
+                        + "el9-8020020200121102609.1",
+                    ],
+                    "tags": ["el8-8020020200121102609.1"],
+                },
+                "modules": ["aisleriot-el8-8020020200121102609"],
+            }
+        },
+        "name": "aisleriot-container",
+        "nvr": "aisleriot-container-el9-9010020220121102609.1",
+        "owner_name": "jdoe",
+        "package_id": 23,
+        "source": "git://pkgs.devel.redhat.com/containers/aisleriot#AISLERIOT_EL9_GIT_DIGEST",
+        "_TYPE": "image",
+        "_TAGS": [],
+        "_ARCHIVES": [
+            {
+                "btype": "image",
+                "extra": {
+                    "docker": {
+                        "config": {
+                            "architecture": "amd64",
+                            "config": {
+                                "Labels": _AISLERIOT_EL9_LABELS,
+                            },
+                            "os": "linux",
+                            "rootfs": {"diff_ids": ["sha256:5a1ad"]},
+                        },
+                        "digests": {
+                            "application/vnd.docker.distribution.manifest.v2+json": "sha256:"
+                            + "ba5eba11c4d226da18ec4a6386263d8b2125fc874c8b4f4f97b31593037ea0bb",
+                        },
+                        "repositories": [
+                            "registry-proxy.engineering.redhat/rh-osbs/aisleriot3:build-3456-x86_64"
+                        ],
+                    },
+                    "image": {
+                        "arch": "x86_64",
+                    },
+                },
+                "id": 18321,
+            }
+        ],
+    },
+    {
+        "build_id": 1063045,
+        "completion_ts": 1598465000.0,
+        "extra": {
+            "image": {
+                "flatpak": True,
+                "index": {
+                    "digests": {
+                        "application/vnd.docker.distribution.manifest.list.v2+json": "sha256:"
+                        + "AISLERIOT_EL9_DIGEST"
+                    },
+                    "floating_tags": ["latest", "el8"],
+                    "pull": [
+                        "registry-proxy.engineering.redhat.com/rh-osbs/aisleriot3@"
+                        + "sha256:AISLERIOT_EL9_DIGEST",
+                        "registry-proxy.engineering.redhat.com/rh-osbs/aisleriot3:"
+                        + "el9-8020020200121102609.2",
+                    ],
+                    "tags": ["el8-8020020200121102609.2"],
+                },
+                "modules": ["aisleriot-el8-8020020200121102609"],
+            }
+        },
+        "name": "aisleriot-container",
+        "nvr": "aisleriot-container-el9-9010020220121102609.2",
+        "owner_name": "jdoe",
+        "package_id": 23,
+        "source": "git://pkgs.devel.redhat.com/containers/aisleriot#AISLERIOT_EL9_2_GIT_DIGEST",
+        "_TYPE": "image",
+        "_TAGS": [],
+        "_ARCHIVES": [
+            {
+                "btype": "image",
+                "extra": {
+                    "docker": {
+                        "config": {
+                            "architecture": "amd64",
+                            "config": {
+                                "Labels": _AISLERIOT_EL9_LABELS,
+                            },
+                            "os": "linux",
+                            "rootfs": {"diff_ids": ["sha256:5a1ad"]},
+                        },
+                        "digests": {
+                            "application/vnd.docker.distribution.manifest.v2+json": "sha256:AISLERIOT_EL9_2_MANIFEST_DIGEST",
+                        },
+                        "repositories": [
+                            "registry-proxy.engineering.redhat/rh-osbs/aisleriot3:build-3456-x86_64"
+                        ],
+                    },
+                    "image": {
+                        "arch": "x86_64",
+                    },
+                },
+                "id": 19321,
+            }
+        ],
+    },
+    {
+        "build_id": 1063046,
+        "completion_ts": 1598466000.0,
+        "extra": {
+            "image": {
+                "index": {
+                    "digests": {
+                        "application/vnd.docker.distribution.manifest.list.v2+json": "sha256:TESTREPO_DIGEST"
+                    },
+                    "floating_tags": ["latest", "el8"],
+                    "pull": [
+                        "registry-proxy.engineering.redhat.com/rh-osbs/testrepo@"
+                        + "sha256:TESTREPO_DIGEST",
+                        "registry-proxy.engineering.redhat.com/rh-osbs/testrepo:" + "1.2.3-1",
+                    ],
+                    "tags": ["1.2.3-1"],
                 }
             }
         },
-        'name': 'testrepo-container',
-        'nvr': 'testrepo-container-1.2.3-1',
-        'owner_name': 'jdoe',
-        'package_id': 24,
-        'source': 'git://pkgs.devel.redhat.com/containers/testrepo#TESTREPO_GIT_DIGEST',
-        '_TYPE': 'image',
-        '_TAGS': [],
-        '_ARCHIVES': [
+        "name": "testrepo-container",
+        "nvr": "testrepo-container-1.2.3-1",
+        "owner_name": "jdoe",
+        "package_id": 24,
+        "source": "git://pkgs.devel.redhat.com/containers/testrepo#TESTREPO_GIT_DIGEST",
+        "_TYPE": "image",
+        "_TAGS": [],
+        "_ARCHIVES": [
             {
-                'btype': 'image',
-                'extra': {
-                    'docker': {
-                        'config': {
-                            'architecture': 'amd64',
-                            'config': {
-                            },
-                            'os': 'linux',
-                            'rootfs': {
-                                'diff_ids': ['sha256:5a1ad']
-                            },
+                "btype": "image",
+                "extra": {
+                    "docker": {
+                        "config": {
+                            "architecture": "amd64",
+                            "config": {},
+                            "os": "linux",
+                            "rootfs": {"diff_ids": ["sha256:5a1ad"]},
                         },
-                        'digests': {
-                            'application/vnd.docker.distribution.manifest.v2+json':
-                            'sha256:' +
-                                'babb1ed1c4d226da18ec4a6386263d8b2125fc874c8b4f4f97b31593037ea0bb',
+                        "digests": {
+                            "application/vnd.docker.distribution.manifest.v2+json": "sha256:"
+                            + "babb1ed1c4d226da18ec4a6386263d8b2125fc874c8b4f4f97b31593037ea0bb",
                         },
-                        'repositories': [
-                            'registry-proxy.engineering.redhat/rh-osbs/testrepo:build-6789-x86_64'
-                        ]
+                        "repositories": [
+                            "registry-proxy.engineering.redhat/rh-osbs/testrepo:build-6789-x86_64"
+                        ],
                     },
-                    'image': {
-                        'arch': 'x86_64',
-                    }
+                    "image": {
+                        "arch": "x86_64",
+                    },
                 },
-                'id': 17321,
+                "id": 17321,
             },
             {
-                'btype': 'image',
-                'extra': {
-                    'docker': {
-                        'config': {
-                            'architecture': 'ppc64le',
-                            'config': {
-                            },
-                            'os': 'linux',
-                            'rootfs': {
-                                'diff_ids': ['sha256:5a1ad']
-                            },
+                "btype": "image",
+                "extra": {
+                    "docker": {
+                        "config": {
+                            "architecture": "ppc64le",
+                            "config": {},
+                            "os": "linux",
+                            "rootfs": {"diff_ids": ["sha256:5a1ad"]},
                         },
-                        'digests': {
-                            'application/vnd.docker.distribution.manifest.v2+json':
-                            'sha256:' +
-                                'fl055ed1c4d226da18ec4a6386263d8b2125fc874c8b4f4f97b31593037ea0bb',
+                        "digests": {
+                            "application/vnd.docker.distribution.manifest.v2+json": "sha256:"
+                            + "fl055ed1c4d226da18ec4a6386263d8b2125fc874c8b4f4f97b31593037ea0bb",
                         },
-                        'repositories': [
-                            'registry-proxy.engineering.redhat/rh-osbs/testrepo:build-6789-ppc64le'
-                        ]
+                        "repositories": [
+                            "registry-proxy.engineering.redhat/rh-osbs/testrepo:build-6789-ppc64le"
+                        ],
                     },
-                    'image': {
-                        'arch': 'ppc64le',
-                    }
+                    "image": {
+                        "arch": "ppc64le",
+                    },
                 },
-                'id': 17322,
+                "id": 17322,
             },
-        ]
+        ],
     },
     # An image, but not a container image
     {
-        'build_id': 636564,
-        'completion_ts': 1515068116.53497,
-        'extra': None,
-        'name': 'rhel-guest-image',
-        'nvr': 'rhel-guest-image-8.0-1114',
-        'owner_name': 'jdoe',
-        'package_id': 42902,
-        'source': None,
-        '_TYPE': 'image',
-        '_TAGS': ['release-candidate'],
-        '_ARCHIVES': [
+        "build_id": 636564,
+        "completion_ts": 1515068116.53497,
+        "extra": None,
+        "name": "rhel-guest-image",
+        "nvr": "rhel-guest-image-8.0-1114",
+        "owner_name": "jdoe",
+        "package_id": 42902,
+        "source": None,
+        "_TYPE": "image",
+        "_TAGS": ["release-candidate"],
+        "_ARCHIVES": [
             {
-                'extra': None,
-                'filename': 'rhel-guest-image-8.0-1114.x86_64.qcow2',
-                'id': 2217961,
+                "extra": None,
+                "filename": "rhel-guest-image-8.0-1114.x86_64.qcow2",
+                "id": 2217961,
             }
-        ]
-    }
+        ],
+    },
 ]
 
 
 _KOJI_TAGS: Dict[str, List[str]] = {
-    'release-candidate': [],
-    'release-candidate-2': [],
-    'release-candidate-3': ['release-candidate', 'release-candidate-2'],
-    'release-candidate-4': [],
+    "release-candidate": [],
+    "release-candidate-2": [],
+    "release-candidate-3": ["release-candidate", "release-candidate-2"],
+    "release-candidate-4": [],
 }
 
 
 def _koji_get_build(build_id):
     if isinstance(build_id, int):
-        key = 'build_id'
+        key = "build_id"
     else:
-        key = 'nvr'
+        key = "nvr"
 
     for build in _KOJI_BUILDS:
         if build[key] == build_id:
@@ -538,16 +518,16 @@ def _koji_get_build(build_id):
 
 def _koji_get_package_id(name):
     for build in _KOJI_BUILDS:
-        if build['name'] == name:
-            return build['package_id']
+        if build["name"] == name:
+            return build["package_id"]
 
     raise RuntimeError("Package {} not found".format(name))
 
 
 def _koji_list_archives(build_id):
     for build in _KOJI_BUILDS:
-        if build['build_id'] == build_id:
-            return build['_ARCHIVES']
+        if build["build_id"] == build_id:
+            return build["_ARCHIVES"]
 
     raise RuntimeError("Build {} not found".format(build_id))
 
@@ -555,7 +535,7 @@ def _koji_list_archives(build_id):
 def _koji_list_builds(build_id, type=None):
     result = []
     for build in _KOJI_BUILDS:
-        if type is None or build['_TYPE'] == type:
+        if type is None or build["_TYPE"] == type:
             result.append(build)
 
     return result
@@ -563,7 +543,7 @@ def _koji_list_builds(build_id, type=None):
 
 def _koji_list_tagged(tag, type, latest=False, inherit=False):
     assert latest is True
-    assert type == 'image'
+    assert type == "image"
 
     if inherit:
         all_tags = set()
@@ -580,11 +560,13 @@ def _koji_list_tagged(tag, type, latest=False, inherit=False):
     result = []
     for build in _KOJI_BUILDS:
         for t in all_tags:
-            if t in build['_TAGS']:
-                result.append({
-                    'build_id': build['build_id'],
-                    'nvr': build['nvr'],
-                })
+            if t in build["_TAGS"]:
+                result.append(
+                    {
+                        "build_id": build["build_id"],
+                        "nvr": build["nvr"],
+                    }
+                )
                 continue
 
     return result
@@ -592,8 +574,8 @@ def _koji_list_tagged(tag, type, latest=False, inherit=False):
 
 def _koji_list_tags(build_id):
     for build in _KOJI_BUILDS:
-        if build['build_id'] == build_id:
-            return [{'name': t} for t in build['_TAGS']]
+        if build["build_id"] == build_id:
+            return [{"name": t} for t in build["_TAGS"]]
 
     raise RuntimeError("Build {} not found".format(build_id))
 
@@ -601,11 +583,10 @@ def _koji_list_tags(build_id):
 def mock_brew(f):
     @wraps(f)
     def wrapper(*args, **kwargs):
-        with patch.multiple('koji',
-                            read_config=DEFAULT,
-                            grab_session_options=DEFAULT,
-                            ClientSession=DEFAULT) as mocks:
-            ClientSession = mocks['ClientSession']
+        with patch.multiple(
+            "koji", read_config=DEFAULT, grab_session_options=DEFAULT, ClientSession=DEFAULT
+        ) as mocks:
+            ClientSession = mocks["ClientSession"]
 
             session = MagicMock()
             ClientSession.return_value = session
@@ -624,24 +605,36 @@ def mock_brew(f):
 
 def _odcs_get_compose_callback(request):
     path = urlparse(request.url).path
-    update_id = int(path.split('/')[-1])
+    update_id = int(path.split("/")[-1])
 
     if update_id == 12345:
-        return (200, {}, json.dumps({
-            "source_type": 2,
-            "source": 'aisleriot:el8:8020020200121102609:73699f59',
-        }))
+        return (
+            200,
+            {},
+            json.dumps(
+                {
+                    "source_type": 2,
+                    "source": "aisleriot:el8:8020020200121102609:73699f59",
+                }
+            ),
+        )
     elif update_id == 34567:
-        return (200, {}, json.dumps({
-          "source": "rhel-8-for-x86_64-appstream-eus-rpms__8_DOT_4",
-          "source_type": 4,
-        }))
+        return (
+            200,
+            {},
+            json.dumps(
+                {
+                    "source": "rhel-8-for-x86_64-appstream-eus-rpms__8_DOT_4",
+                    "source_type": 4,
+                }
+            ),
+        )
     else:
-        return (404, {}, json.dumps({
-            "error": "Not Found",
-            "message": "No such compose found.",
-            "status": 404
-        }))
+        return (
+            404,
+            {},
+            json.dumps({"error": "Not Found", "message": "No such compose found.", "status": 404}),
+        )
 
 
 def mock_odcs(f):
@@ -652,7 +645,7 @@ def mock_odcs(f):
                 method=responses.GET,
                 url=re.compile(r"https://odcs.example.com/api/1/composes/(\d+)"),
                 callback=_odcs_get_compose_callback,
-                content_type='application/json'
+                content_type="application/json",
             )
 
             return f(*args, **kwargs)
@@ -678,5 +671,5 @@ class ImpatientPopen(subprocess.Popen):
 
 @contextmanager
 def timeout_first_popen_wait():
-    with patch('subprocess.Popen', side_effect=ImpatientPopen):
+    with patch("subprocess.Popen", side_effect=ImpatientPopen):
         yield

--- a/tools/create-test-data.py
+++ b/tools/create-test-data.py
@@ -12,7 +12,6 @@ import click
 import koji
 import requests
 
-
 # The data we use is meant to be a point-in-time snapshot of Fedora at this
 # date.
 DATE = "2022-10-01 00:00:00"
@@ -24,18 +23,18 @@ def show(msg, indent):
 
 
 def get_btype(build):
-    extra = build.get('extra')
+    extra = build.get("extra")
     if extra:
-        typeinfo = extra.get('typeinfo')
+        typeinfo = extra.get("typeinfo")
     else:
         typeinfo = None
 
-    if extra and extra.get('image'):
-        return 'image'
-    elif typeinfo and typeinfo.get('module'):
-        return 'module'
+    if extra and extra.get("image"):
+        return "image"
+    elif typeinfo and typeinfo.get("module"):
+        return "module"
     else:
-        return 'rpm'
+        return "rpm"
 
 
 class Downloader:
@@ -52,10 +51,10 @@ class Downloader:
             self._load_build_ids(self.base)
             self._load_update_info(self.base)
 
-        koji_config_file = os.path.join(os.path.dirname(__file__), '../koji.conf')
-        options = koji.read_config(profile_name='fedora', user_config=koji_config_file)
+        koji_config_file = os.path.join(os.path.dirname(__file__), "../koji.conf")
+        options = koji.read_config(profile_name="fedora", user_config=koji_config_file)
         session_opts = koji.grab_session_options(options)
-        self.koji_session = koji.ClientSession(options['server'], session_opts)
+        self.koji_session = koji.ClientSession(options["server"], session_opts)
 
     def _check_existing(self, relative, *, indent=0):
         dest = os.path.join(self.output, relative)
@@ -71,34 +70,34 @@ class Downloader:
             return False, dest
 
     def _load_build_ids(self, load_from):
-        for ent in os.scandir(os.path.join(load_from, 'builds')):
-            if ent.name.endswith('.json.gz'):
-                with gzip.open(ent.path, 'rt') as f:
+        for ent in os.scandir(os.path.join(load_from, "builds")):
+            if ent.name.endswith(".json.gz"):
+                with gzip.open(ent.path, "rt") as f:
                     build = json.load(f)
-                self.build_id_to_nvr[build['build_id']] = build['nvr']
-                if get_btype(build) == 'module':
-                    n, v, r = build['nvr'].rsplit('-', 2)
-                    nvr_short = n + '-' + v + '-' + r.split('.')[0]
-                    self.module_nvr_short_to_nvr[nvr_short] = build['nvr']
+                self.build_id_to_nvr[build["build_id"]] = build["nvr"]
+                if get_btype(build) == "module":
+                    n, v, r = build["nvr"].rsplit("-", 2)
+                    nvr_short = n + "-" + v + "-" + r.split(".")[0]
+                    self.module_nvr_short_to_nvr[nvr_short] = build["nvr"]
 
     def _load_update_info(self, load_from):
-        fname = os.path.join(load_from, 'updates.index.gz')
+        fname = os.path.join(load_from, "updates.index.gz")
         if os.path.exists(fname):
-            with gzip.open(fname, 'rt') as f:
+            with gzip.open(fname, "rt") as f:
                 self.base_update_info = json.load(f)
 
     def save_update_info(self):
-        fname = os.path.join(self.output, 'updates.index.gz')
-        with gzip.open(fname, 'wt') as f:
+        fname = os.path.join(self.output, "updates.index.gz")
+        with gzip.open(fname, "wt") as f:
             json.dump(self.update_info, f, indent=4)
 
     def create_directories(self):
         if os.path.exists(self.output):
             print(f"{self.output} already exists", file=sys.stderr)
         os.mkdir(self.output)
-        os.mkdir(os.path.join(self.output, 'updates'))
-        os.mkdir(os.path.join(self.output, 'builds'))
-        os.mkdir(os.path.join(self.output, 'git'))
+        os.mkdir(os.path.join(self.output, "updates"))
+        os.mkdir(os.path.join(self.output, "builds"))
+        os.mkdir(os.path.join(self.output, "git"))
 
     def download_build(self, *, nvr=None, build_id=None, indent=0):
         if nvr is None and build_id is None:
@@ -109,10 +108,10 @@ class Downloader:
 
         build = None
         if nvr:
-            exists, output_file = self._check_existing(f'builds/{nvr}.json.gz')
+            exists, output_file = self._check_existing(f"builds/{nvr}.json.gz")
             if exists:
                 show(f"{nvr}: already downloaded", indent)
-                with gzip.open(output_file, 'rt') as f:
+                with gzip.open(output_file, "rt") as f:
                     build = json.load(f)
         else:
             exists = False
@@ -123,187 +122,196 @@ class Downloader:
             else:
                 build = self.koji_session.getBuild(build_id)
 
-            nvr = build['nvr']
+            nvr = build["nvr"]
             show(f"{nvr}: downloaded", indent)
 
-        output_file = os.path.join(self.output, f'builds/{nvr}.json.gz')
-        self.build_id_to_nvr[build['build_id']] = build['nvr']
+        output_file = os.path.join(self.output, f"builds/{nvr}.json.gz")
+        self.build_id_to_nvr[build["build_id"]] = build["nvr"]
 
         indent += 4
         btype = get_btype(build)
 
         if not exists:
-            if btype == 'image' or btype == 'module':
-                archives = self.koji_session.listArchives(build['id'])
-                build['archives'] = []
+            if btype == "image" or btype == "module":
+                archives = self.koji_session.listArchives(build["id"])
+                build["archives"] = []
                 show("Listing archives", indent)
                 seen = set()
                 for archive in archives:
-                    if btype == 'module':
-                        if archive['filename'] not in ('modulemd.txt', 'modulemd.x86_64.txt'):
+                    if btype == "module":
+                        if archive["filename"] not in ("modulemd.txt", "modulemd.x86_64.txt"):
                             continue
-                    build['archives'].append(archive)
+                    build["archives"].append(archive)
                     show(f"Listing rpms for archive {archive['id']}", indent)
-                    components = self.koji_session.listRPMs(imageID=archive['id'])
-                    archive['components'] = []
+                    components = self.koji_session.listRPMs(imageID=archive["id"])
+                    archive["components"] = []
                     for c in components:
-                        if c['arch'] not in ('x86_64', 'noarch'):
+                        if c["arch"] not in ("x86_64", "noarch"):
                             continue
-                        archive['components'].append(c)
+                        archive["components"].append(c)
 
-            with gzip.open(output_file, 'wt') as f:
+            with gzip.open(output_file, "wt") as f:
                 json.dump(build, f, indent=4)
 
         # Now find extra builds to download
 
-        if btype == 'image' or btype == 'module':
+        if btype == "image" or btype == "module":
             seen = set()
-            for archive in build['archives']:
-                for c in archive['components']:
-                    if not c['build_id'] in seen:
-                        seen.add(c['build_id'])
-                        nvr = self.download_build(build_id=c['build_id'], indent=indent)
-                        if btype == 'image':
-                            self.image_packages.add(nvr.rsplit('-', 2)[0])
+            for archive in build["archives"]:
+                for c in archive["components"]:
+                    if c["build_id"] not in seen:
+                        seen.add(c["build_id"])
+                        nvr = self.download_build(build_id=c["build_id"], indent=indent)
+                        if btype == "image":
+                            self.image_packages.add(nvr.rsplit("-", 2)[0])
 
-        if btype == 'image':
-            for m in build['extra']['image']['modules']:
+        if btype == "image":
+            for m in build["extra"]["image"]["modules"]:
                 if m in self.module_nvr_short_to_nvr:
                     self.download_build(nvr=self.module_nvr_short_to_nvr[m], indent=indent)
                 else:
-                    module_name = m.rsplit('-', 2)[0]
+                    module_name = m.rsplit("-", 2)[0]
                     package_id = self.koji_session.getPackageID(module_name)
-                    for module_build in self.koji_session.listBuilds(type='module',
-                                                                     packageID=package_id):
-                        if module_build['nvr'].startswith(m):
-                            self.download_build(nvr=module_build['nvr'], indent=indent + 4)
+                    for module_build in self.koji_session.listBuilds(
+                        type="module", packageID=package_id
+                    ):
+                        if module_build["nvr"].startswith(m):
+                            self.download_build(nvr=module_build["nvr"], indent=indent + 4)
 
         return nvr
 
     def download_tag_data(self, indent=0):
         self.tagged_packages = {}
-        for tag in ['f36', 'f35']:
-            exists, output_file = self._check_existing(f'tags/{tag}.json.gz')
+        for tag in ["f36", "f35"]:
+            exists, output_file = self._check_existing(f"tags/{tag}.json.gz")
             if not exists:
-                show(f'Downloading tag history for {tag}', indent=indent)
-                result = self.koji_session.queryHistory(tables=['tag_listing'], tag=tag)
-                filtered_result = [r
-                                   for r in result['tag_listing']
-                                   if r['name'] in self.image_packages]
+                show(f"Downloading tag history for {tag}", indent=indent)
+                result = self.koji_session.queryHistory(tables=["tag_listing"], tag=tag)
+                filtered_result = [
+                    r for r in result["tag_listing"] if r["name"] in self.image_packages
+                ]
                 d = os.path.dirname(output_file)
                 if not os.path.exists(d):
                     os.makedirs(d)
-                with gzip.open(output_file, 'wt') as f:
+                with gzip.open(output_file, "wt") as f:
                     json.dump(filtered_result, f, indent=4)
             else:
-                show(f'Using existing tag history for {tag}', indent=indent)
-                with gzip.open(output_file, 'rt') as f:
+                show(f"Using existing tag history for {tag}", indent=indent)
+                with gzip.open(output_file, "rt") as f:
                     filtered_result = json.load(f)
 
             indent += 4
             for r in filtered_result:
-                self.download_build(nvr=f"{r['name']}-{r['version']}-{r['release']}",
-                                    indent=indent + 4)
+                self.download_build(
+                    nvr=f"{r['name']}-{r['version']}-{r['release']}", indent=indent + 4
+                )
 
     def download_package_details(self, *, indent=0):
         for package in sorted(self.image_packages):
-            self.download_updates('rpm', package, indent=indent)
-            self.dump_git(os.path.join('rpms', package), indent=indent + 4)
+            self.download_updates("rpm", package, indent=indent)
+            self.dump_git(os.path.join("rpms", package), indent=indent + 4)
 
     def download_updates(self, content_type, package, *, releases=None, date=DATE, indent=0):
         key = f"{content_type}/{package}"
 
-        if (key in self.update_info or
-            (key in self.base_update_info and
-             self.base_update_info[key]['date'] == date)):
-
+        if key in self.update_info or (
+            key in self.base_update_info and self.base_update_info[key]["date"] == date
+        ):
             show(f"{key}: already downloaded updates", indent)
             if key not in self.update_info:
                 self.update_info[key] = self.base_update_info[key]
-                for update in self.update_info[key]['updates']:
-                    src = os.path.join(self.base, 'updates', update + '.json.gz')
-                    dest = os.path.join(self.output, 'updates', update + '.json.gz')
+                for update in self.update_info[key]["updates"]:
+                    src = os.path.join(self.base, "updates", update + ".json.gz")
+                    dest = os.path.join(self.output, "updates", update + ".json.gz")
 
                     shutil.copy(src, dest)
 
-                    with gzip.open(src, 'rt') as f:
+                    with gzip.open(src, "rt") as f:
                         r = json.load(f)
-                        for b in r['builds']:
-                            build_name = b['nvr'].rsplit('-', 2)[0]
+                        for b in r["builds"]:
+                            build_name = b["nvr"].rsplit("-", 2)[0]
                             if build_name == package:
-                                self.download_build(nvr=b['nvr'], indent=indent + 4)
+                                self.download_build(nvr=b["nvr"], indent=indent + 4)
 
             return
 
         show(f"{key}: downloading updates", indent)
 
         if releases is None:
-            if content_type == 'flatpak':
-                releases = ['F36F', 'F35F']
-            elif content_type == 'rpm':
-                releases = ['F36', 'F35']
+            if content_type == "flatpak":
+                releases = ["F36F", "F35F"]
+            elif content_type == "rpm":
+                releases = ["F36", "F35"]
 
         url = "https://bodhi.fedoraproject.org/updates/"
         params = {
-            'page': 1,
-            'rows_per_page': 100,
-            'content_type': content_type,
-            'packages': package,
-            'releases': releases,
-            'submitted_before': date,
+            "page": 1,
+            "rows_per_page": 100,
+            "content_type": content_type,
+            "packages": package,
+            "releases": releases,
+            "submitted_before": date,
         }
 
-        response = requests.get(url,
-                                headers={'Accept': 'application/json'},
-                                params=params)
+        response = requests.get(url, headers={"Accept": "application/json"}, params=params)
         response.raise_for_status()
         response_json = response.json()
 
-        self.update_info[key] = {
-            'date': date,
-            'updates': []
-        }
+        self.update_info[key] = {"date": date, "updates": []}
 
-        for r in response_json['updates']:
-            if ' ' in r['title']:
-                update_name = r['updateid']
+        for r in response_json["updates"]:
+            if " " in r["title"]:
+                update_name = r["updateid"]
             else:
-                update_name = r['title']
-            output_file = os.path.join(self.output, 'updates', update_name + '.json.gz')
-            with gzip.open(output_file, 'wt') as f:
+                update_name = r["title"]
+            output_file = os.path.join(self.output, "updates", update_name + ".json.gz")
+            with gzip.open(output_file, "wt") as f:
                 json.dump(r, f, indent=4)
 
-            self.update_info[key]['updates'].append(update_name)
+            self.update_info[key]["updates"].append(update_name)
 
-            if r['status'] in ('pending', 'testing'):
+            if r["status"] in ("pending", "testing"):
                 print("Error: {update_name} status is {r['status']}", file=sys.stderr)
                 sys.exit(1)
 
-            for b in r['builds']:
-                build_name = b['nvr'].rsplit('-', 2)[0]
+            for b in r["builds"]:
+                build_name = b["nvr"].rsplit("-", 2)[0]
                 if build_name == package:
-                    self.download_build(nvr=b['nvr'], indent=indent + 4)
+                    self.download_build(nvr=b["nvr"], indent=indent + 4)
 
     def do_dump_git(self, tempdir, output_file, pkg):
-        subprocess.check_call(['git', 'clone', '--mirror',
-                               'https://src.fedoraproject.org/' + pkg + '.git'],
-                              cwd=tempdir)
-        repodir = os.path.join(tempdir, os.path.basename(pkg) + '.git')
+        subprocess.check_call(
+            ["git", "clone", "--mirror", "https://src.fedoraproject.org/" + pkg + ".git"],
+            cwd=tempdir,
+        )
+        repodir = os.path.join(tempdir, os.path.basename(pkg) + ".git")
         result = {}
-        branches = subprocess.check_output(['git', 'branch', '-a', '--format=%(refname:lstrip=2)'],
-                                           cwd=repodir, encoding='UTF-8').strip().split('\n')
+        branches = (
+            subprocess.check_output(
+                ["git", "branch", "-a", "--format=%(refname:lstrip=2)"],
+                cwd=repodir,
+                encoding="UTF-8",
+            )
+            .strip()
+            .split("\n")
+        )
         for branch in branches:
-            commits = subprocess.check_output(['git', 'log', '--format=%H', branch],
-                                              cwd=repodir, encoding='UTF-8').strip().split('\n')
+            commits = (
+                subprocess.check_output(
+                    ["git", "log", "--format=%H", branch], cwd=repodir, encoding="UTF-8"
+                )
+                .strip()
+                .split("\n")
+            )
             result[branch] = commits
         d = os.path.dirname(output_file)
         if not os.path.exists(d):
             os.makedirs(d)
-        with gzip.open(output_file, 'wt') as f:
+        with gzip.open(output_file, "wt") as f:
             json.dump(result, f, indent=4)
 
     def dump_git(self, pkg, *, indent=0):
-        exists, output_file = self._check_existing(f'git/{pkg}.json.gz')
+        exists, output_file = self._check_existing(f"git/{pkg}.json.gz")
         if exists:
             show(f"{pkg}.git: already downloaded", indent)
             return
@@ -318,32 +326,32 @@ class Downloader:
 
 
 @click.command()
-@click.option('-o', '--output', required=True,
-              help='Output directory')
-@click.option('-b', '--base',
-              help='Reference directory')
+@click.option("-o", "--output", required=True, help="Output directory")
+@click.option("-b", "--base", help="Reference directory")
 def main(output, base):
     """Download test data"""
     downloader = Downloader(output, base)
 
     downloader.create_directories()
 
-    downloader.download_updates('flatpak', 'baobab')
-    downloader.download_updates('flatpak', 'eog')
-    downloader.download_updates('flatpak', 'feedreader')
-    downloader.download_updates('flatpak', 'quadrapassel')
+    downloader.download_updates("flatpak", "baobab")
+    downloader.download_updates("flatpak", "eog")
+    downloader.download_updates("flatpak", "feedreader")
+    downloader.download_updates("flatpak", "quadrapassel")
 
     # These rpm builds are used when testing modification of Bodhi updates
-    for b in (["gnome-weather-41.0-1.fc35",
-               "gnome-weather-42~beta-1.fc36",
-               "gnome-weather-42~rc-1.fc36",
-               "gnome-weather-42.0-1.fc36",
-               "sushi-41.0-1.fc35"]):
+    for b in [
+        "gnome-weather-41.0-1.fc35",
+        "gnome-weather-42~beta-1.fc36",
+        "gnome-weather-42~rc-1.fc36",
+        "gnome-weather-42.0-1.fc36",
+        "sushi-41.0-1.fc35",
+    ]:
         downloader.download_build(nvr=b)
 
     # Module with multiple contexts
-    downloader.download_build(nvr='django-1.6-20180828135711.9c690d0e')
-    downloader.download_build(nvr='django-1.6-20180828135711.a5b0195c')
+    downloader.download_build(nvr="django-1.6-20180828135711.9c690d0e")
+    downloader.download_build(nvr="django-1.6-20180828135711.a5b0195c")
 
     downloader.download_tag_data()
 
@@ -352,5 +360,5 @@ def main(output, base):
     downloader.save_update_info()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -10,8 +10,10 @@ unset GIT_SSL_CAINFO
 pytest --cov-fail-under=100 "$@"
 
 [ $? == 0 ] || failed="$failed pytest"
-flake8 flatpak_indexer tests tools
-[ $? == 0 ] || failed="$failed flake8"
+ruff format --check flatpak_indexer tests tools
+[ $? == 0 ] || failed="$failed ruff-format"
+ruff check flatpak_indexer tests tools
+[ $? == 0 ] || failed="$failed ruff-check"
 
 set -e +x
 


### PR DESCRIPTION
* Replace flake8 with ruff and use it for both linting and formatting
* Add vscode configuration for ruff
* Reformat entire codebase with Ruff
* Fix a couple of small deprecation/typing warnings as separate commits
