### PR TITLE
Containerfile: allow injecting a CA certificate into the image

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -18,9 +18,17 @@ FROM ${PYTHON_IMAGE} as builder
 ARG FLATPAK_INDEXER_UPDATE_TEST_DATA=false
 ENV FLATPAK_INDEXER_UPDATE_TEST_DATA=${FLATPAK_INDEXER_UPDATE_TEST_DATA}
 
+USER 0
+# Add custom CA certificates
+ADD ca-certs /tmp/ca-certs
+RUN find /tmp/ca-certs \
+        -name '*.cert' -o -name '*.crt' -o -name '*.pem' \
+        -exec cp {} /etc/pki/ca-trust/source/anchors/ \; && \
+    update-ca-trust
+ENV REQUESTS_CA_BUNDLE=/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt
+
 # Add application sources to a directory that the assemble script expects them
 # and set permissions so that the container runs without root access
-USER 0
 ADD . /tmp/src
 RUN /usr/bin/fix-permissions /tmp/src
 USER 1001
@@ -32,6 +40,11 @@ FROM ${PYTHON_MINIMAL_IMAGE}
 
 USER 0
 RUN microdnf -y install time && microdnf clean all
+
+# Add custom CA certificates
+ADD ca-certs /tmp/ca-certs
+COPY --from=builder /etc/pki/ca-trust/ /etc/pki/ca-trust/
+ENV REQUESTS_CA_BUNDLE=/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt
 USER 1001
 
 # Copy the tar-diff binary from the tar-diff-builder image

--- a/app.sh
+++ b/app.sh
@@ -1,10 +1,5 @@
 #!/bin/sh
 
-# These is set to build-time specific location when building the Red Hat-internal
-# image; unset them to avoid breaking things at runtime.
-unset REQUESTS_CA_BUNDLE
-unset GIT_SSL_CAINFO
-
 for d in deltas icons ; do
     [ -d $OUTPUT_DIR/$d ] || mkdir -p -m 0755 $OUTPUT_DIR/$d
 done

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-# These are set to build-time specific location when building the Red Hat-internal
-# image; unset them to avoid breaking things at runtime.
-unset REQUESTS_CA_BUNDLE
-unset GIT_SSL_CAINFO
-
 modules=()
 pytest_args=()
 all=true


### PR DESCRIPTION
Allow injecting a CA certificate into the container image, by putting it into the ca-certs/ directory in the build environment. This will allow us to get rid of some hacks when building the internal Red Hat image.

Remove some unsetting of environment variables that is longer needed without those hacks.