### PR TITLE
Containerfile: fix logic for copying certificates

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -22,7 +22,7 @@ USER 0
 # Add custom CA certificates
 ADD ca-certs /tmp/ca-certs
 RUN find /tmp/ca-certs \
-        -name '*.cert' -o -name '*.crt' -o -name '*.pem' \
+        \( -name '*.cert' -o -name '*.crt' -o -name '*.pem' \) \
         -exec cp {} /etc/pki/ca-trust/source/anchors/ \; && \
     update-ca-trust
 ENV REQUESTS_CA_BUNDLE=/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt
@@ -42,7 +42,6 @@ USER 0
 RUN microdnf -y install time && microdnf clean all
 
 # Add custom CA certificates
-ADD ca-certs /tmp/ca-certs
 COPY --from=builder /etc/pki/ca-trust/ /etc/pki/ca-trust/
 ENV REQUESTS_CA_BUNDLE=/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt
 USER 1001


### PR DESCRIPTION
Missing parentheses caused only files with the .pem suffix to be copied.