### PR TITLE
Fix FLATPAK_INDEXER_UPDATE_TEST_DATA for openshift

### DIFF
--- a/.s2i/bin/assemble
+++ b/.s2i/bin/assemble
@@ -9,5 +9,8 @@ fi
 
 if [ "${FLATPAK_INDEXER_UPDATE_TEST_DATA:+set}" = set ] ; then
    cd /opt/app-root/src
+   # When building in openshift, the repo files are writable, but
+   # owned by a different user; tell git this is OK.
+   git config --global --add safe.directory /opt/app-root/src
    exec ./tools/update-test-data.sh --from-cache
 fi

--- a/Containerfile
+++ b/Containerfile
@@ -15,7 +15,7 @@ RUN cd /tmp/src && go build -buildvcs=false -o /opt/app-root/bin/tar-diff ./cmd/
 
 FROM ${PYTHON_IMAGE} as builder
 
-ARG FLATPAK_INDEXER_UPDATE_TEST_DATA=false
+ARG FLATPAK_INDEXER_UPDATE_TEST_DATA=
 ENV FLATPAK_INDEXER_UPDATE_TEST_DATA=${FLATPAK_INDEXER_UPDATE_TEST_DATA}
 
 USER 0


### PR DESCRIPTION
When building in openshift with the Docker strategy, the filesystem ownership mismatches the UID causing git to refuse fetch test data. Configure git to treat the source directory as safe.

Also fix mistake in the containerfile - FLATPAK_INDEXER_UPDATE_TEST_DATA has an effect if it's set to any non-null value, not just "true", so use "" as the default value.