### PR TITLE
Don't use Test prefix to avoid pytest naming convention clash

### DIFF
--- a/tests/test_bodhi_query.py
+++ b/tests/test_bodhi_query.py
@@ -24,13 +24,13 @@ from flatpak_indexer.test.koji import mock_koji
 from flatpak_indexer.test.redis import mock_redis
 
 
-class TestConfig(HttpConfig, KojiConfig, RedisConfig):
+class ConfigTest(HttpConfig, KojiConfig, RedisConfig):
     pass
 
 
 @pytest.fixture
 def session():
-    config = TestConfig.from_str(
+    config = ConfigTest.from_str(
         dedent("""
         koji_config: fedora
         redis_url: redis://localhost

--- a/tests/test_bodhi_query.py
+++ b/tests/test_bodhi_query.py
@@ -24,13 +24,13 @@ from flatpak_indexer.test.koji import mock_koji
 from flatpak_indexer.test.redis import mock_redis
 
 
-class ConfigTest(HttpConfig, KojiConfig, RedisConfig):
+class ConfigForTests(HttpConfig, KojiConfig, RedisConfig):
     pass
 
 
 @pytest.fixture
 def session():
-    config = ConfigTest.from_str(
+    config = ConfigForTests.from_str(
         dedent("""
         koji_config: fedora
         redis_url: redis://localhost

--- a/tests/test_koji_query.py
+++ b/tests/test_koji_query.py
@@ -23,13 +23,13 @@ from flatpak_indexer.test.koji import make_koji_session, mock_koji
 from flatpak_indexer.test.redis import make_redis_client, mock_redis
 
 
-class TestConfig(KojiConfig, RedisConfig):
+class ConfigTest(KojiConfig, RedisConfig):
     pass
 
 
 @fixture
 def session():
-    config = TestConfig.from_str(
+    config = ConfigTest.from_str(
         dedent("""
         koji_config: fedora
         redis_url: redis://localhost

--- a/tests/test_koji_query.py
+++ b/tests/test_koji_query.py
@@ -23,13 +23,13 @@ from flatpak_indexer.test.koji import make_koji_session, mock_koji
 from flatpak_indexer.test.redis import make_redis_client, mock_redis
 
 
-class ConfigTest(KojiConfig, RedisConfig):
+class ConfigForTests(KojiConfig, RedisConfig):
     pass
 
 
 @fixture
 def session():
-    config = ConfigTest.from_str(
+    config = ConfigForTests.from_str(
         dedent("""
         koji_config: fedora
         redis_url: redis://localhost


### PR DESCRIPTION
Fixes warnings like this:

	PytestCollectionWarning: cannot collect test class 'TestConfig' because it has a __init__ constructor