### PR TITLE
Initial debug config for VS Code and derivatives

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
             "name": "flatpak-indexer",
             "type": "debugpy",
             "request": "launch",
-            "program": "${workspaceFolder}/.venv/bin/flatpak-indexer",
+            "module": "flatpak_indexer.cli",
             "args": [
                 "-c",
                 "${input:configFile}",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -28,6 +28,20 @@
             ],
             "console": "integratedTerminal",
             "justMyCode": false,
+        },
+        {
+            "name": "flatpak-indexer: daemon (fedora)",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "flatpak_indexer.cli",
+            "args": [
+                "-c",
+                "config-fedora.yaml",
+                "-v",
+                "daemon"
+            ],
+            "console": "integratedTerminal",
+            "justMyCode": false,
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,46 +2,37 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "flatpak-indexer: index (fedora)",
+            "name": "flatpak-indexer",
             "type": "debugpy",
             "request": "launch",
             "program": "${workspaceFolder}/.venv/bin/flatpak-indexer",
             "args": [
                 "-c",
-                "config-fedora.yaml",
+                "${input:configFile}",
                 "-v",
-                "index"
+                "${input:subcommand}"
             ],
             "console": "integratedTerminal",
             "justMyCode": false
-        },
+        }
+    ],
+    "inputs": [
         {
-            "name": "flatpak-indexer: differ (fedora)",
-            "type": "debugpy",
-            "request": "launch",
-            "program": "${workspaceFolder}/.venv/bin/flatpak-indexer",
-            "args": [
-                "-c",
-                "config-fedora.yaml",
-                "-v",
-                "differ"
-            ],
-            "console": "integratedTerminal",
-            "justMyCode": false
-        },
-        {
-            "name": "flatpak-indexer: daemon (fedora)",
-            "type": "debugpy",
-            "request": "launch",
-            "program": "${workspaceFolder}/.venv/bin/flatpak-indexer",
-            "args": [
-                "-c",
-                "config-fedora.yaml",
-                "-v",
+            "id": "subcommand",
+            "type": "pickString",
+            "description": "Select the subcommand to run",
+            "options": [
+                "index",
+                "differ",
                 "daemon"
             ],
-            "console": "integratedTerminal",
-            "justMyCode": false
+            "default": "index"
+        },
+        {
+            "id": "configFile",
+            "type": "promptString",
+            "description": "Path to config file",
+            "default": "config-fedora.yaml"
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,34 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "flatpak-indexer: index (fedora)",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "flatpak_indexer.cli",
+            "args": [
+                "-c",
+                "config-fedora.yaml",
+                "-v",
+                "index"
+            ],
+            "console": "integratedTerminal",
+            "justMyCode": false,
+        },
+        {
+            "name": "flatpak-indexer: differ (fedora)",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "flatpak_indexer.cli",
+            "args": [
+                "-c",
+                "config-fedora.yaml",
+                "-v",
+                "differ"
+            ],
+            "console": "integratedTerminal",
+            "justMyCode": false,
+        }
+    ]
+}
+

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
             "name": "flatpak-indexer: index (fedora)",
             "type": "debugpy",
             "request": "launch",
-            "module": "flatpak_indexer.cli",
+            "program": "${workspaceFolder}/.venv/bin/flatpak-indexer",
             "args": [
                 "-c",
                 "config-fedora.yaml",
@@ -13,13 +13,13 @@
                 "index"
             ],
             "console": "integratedTerminal",
-            "justMyCode": false,
+            "justMyCode": false
         },
         {
             "name": "flatpak-indexer: differ (fedora)",
             "type": "debugpy",
             "request": "launch",
-            "module": "flatpak_indexer.cli",
+            "program": "${workspaceFolder}/.venv/bin/flatpak-indexer",
             "args": [
                 "-c",
                 "config-fedora.yaml",
@@ -27,13 +27,13 @@
                 "differ"
             ],
             "console": "integratedTerminal",
-            "justMyCode": false,
+            "justMyCode": false
         },
         {
             "name": "flatpak-indexer: daemon (fedora)",
             "type": "debugpy",
             "request": "launch",
-            "module": "flatpak_indexer.cli",
+            "program": "${workspaceFolder}/.venv/bin/flatpak-indexer",
             "args": [
                 "-c",
                 "config-fedora.yaml",
@@ -41,8 +41,7 @@
                 "daemon"
             ],
             "console": "integratedTerminal",
-            "justMyCode": false,
+            "justMyCode": false
         }
     ]
 }
-

--- a/flatpak_indexer/cli.py
+++ b/flatpak_indexer/cli.py
@@ -107,3 +107,7 @@ def index(ctx):
         finally:
             updater.stop()
     indexer.index(registry_data)
+
+
+if __name__ == "__main__":
+    cli()

--- a/flatpak_indexer/cli.py
+++ b/flatpak_indexer/cli.py
@@ -107,7 +107,3 @@ def index(ctx):
         finally:
             updater.stop()
     indexer.index(registry_data)
-
-
-if __name__ == "__main__":
-    cli()

--- a/flatpak_indexer/cli.py
+++ b/flatpak_indexer/cli.py
@@ -110,4 +110,4 @@ def index(ctx):
 
 
 if __name__ == "__main__":
-    cli()
+    cli()  # pragma: no cover


### PR DESCRIPTION
Add basic debug config for `index`, `differ` and `daemon` sub commands run locally.

This is a basis that can be expanded to include other configurations in the future.