### PR TITLE
Fix valkey deployment in OpenShift

### DIFF
--- a/redis/Dockerfile
+++ b/redis/Dockerfile
@@ -3,7 +3,7 @@ FROM fedora:latest
 RUN dnf -y update && dnf install -y valkey && dnf clean all
 
 RUN chmod 0770 /etc/valkey
-RUN mkdir /run/valkey && chown valkey:valkey /run/valkey
+RUN mkdir -m 0770 /run/valkey && chown valkey:0 /run/valkey
 
 RUN mkdir -m 0770 /data && chown valkey:0 /data
 VOLUME /data


### PR DESCRIPTION
OpenShift deployment is using random UID and GID 0 for user. The Dockerfile for valkey (redis) correctly set the owner of /run/valkey to group 0, but the group doesn't have permissions to write to this directory. This commit is fixing that.