### PR TITLE
Skip file cleanup if updater failed

### DIFF
--- a/flatpak_indexer/cli.py
+++ b/flatpak_indexer/cli.py
@@ -59,11 +59,18 @@ def daemon(ctx):
             last_update_time = time.time()
 
             registry_data: Dict[str, RegistryModel] = {}
+            update_failed = False
             for updater in updaters:
                 try:
                     updater.update(registry_data)
                 except Exception:
-                    logger.exception("Failed to update data sources")
+                    logger.exception("Failed to update data source: %s", type(updater).__name__)
+                    update_failed = True
+                    break
+
+            if update_failed:
+                logger.exception("Skipping both indexing and cleanup due to failed updaters")
+                continue
 
             cleaner.reset()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -104,6 +104,41 @@ def test_daemon_exception(tmp_path, where):
             assert exception_count == 2
 
 
+def test_daemon_skip_indexing_and_cleanup_on_updater_exception(tmp_path, caplog):
+    config_path = write_config(tmp_path, CONFIG)
+    os.environ["OUTPUT_DIR"] = str(tmp_path)
+
+    sleep_count = 0
+
+    def mock_sleep(secs):
+        nonlocal sleep_count
+        sleep_count += 1
+        if sleep_count == 2:
+            sys.exit(42)
+
+    runner = CliRunner()
+
+    with (
+        patch("flatpak_indexer.cli.time.sleep", side_effect=mock_sleep),
+        patch(
+            "flatpak_indexer.datasource.pyxis.updater.PyxisUpdater.update",
+            side_effect=Exception("Failed to update data source!"),
+        ) as mock_update,
+        patch("flatpak_indexer.indexer.Indexer.index") as mock_index,
+        patch("flatpak_indexer.cleaner.Cleaner.clean") as mock_clean,
+    ):
+        result = runner.invoke(
+            cli, ["--config-file", config_path, "daemon"], catch_exceptions=False
+        )
+
+        mock_update.assert_called()
+        mock_index.assert_not_called()
+        mock_clean.assert_not_called()
+        assert "Skipping both indexing and cleanup due to failed updaters" in caplog.text
+
+        assert result.exit_code == 42
+
+
 @mock_brew
 @mock_odcs
 @mock_pyxis

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -62,6 +62,7 @@ def test_daemon(tmp_path):
 
 
 @mock_brew
+@mock_odcs
 @mock_pyxis
 @mock_redis
 @pytest.mark.parametrize(


### PR DESCRIPTION
When a data source updater keeps throwing exceptions, previously generated
deltas don't get referenced by the indexer. If this situation goes on for a
duration of at least `clean_files_after`, the cleaner eventually deletes such
deltas.

Most of the time this is not what we want, as a transient failure like a
certificate expiration - if not addressed quickly - causes at least the
following issues:

1. a long batch of delta files need to be re-generated, which can take days;
2. related flatpak updates - including security fixes - are not visible to
   clients.

To address both of these issues, we skip files cleanup when *any*
updater threw an exception in the current indexing cycle.

Furthermore, to prevent the creation of a partial, and possibly inconsistent
index, we also skip indexing altogether, preserving the last successfully
generated index.