### PR TITLE
Add more verbose debug output

### DIFF
--- a/flatpak_indexer/cli.py
+++ b/flatpak_indexer/cli.py
@@ -17,8 +17,9 @@ logger = logging.getLogger(__name__)
 @click.group()
 @click.pass_context
 @click.option("--config-file", "-c", required=True, help="Config file")
-@click.option("-v", "--verbose", is_flag=True, help="Show verbose debugging output")
-def cli(ctx, config_file, verbose):
+@click.option("-v", "--verbose", is_flag=True, help="Show verbose info output")
+@click.option("-vv", "--verbose-debug", is_flag=True, help="Show verbose debugging output")
+def cli(ctx, config_file, verbose, verbose_debug):
     cfg = Config.from_path(config_file)
 
     ctx.obj = {
@@ -29,6 +30,8 @@ def cli(ctx, config_file, verbose):
     logging.basicConfig(level=logging.WARNING, format=FORMAT)
     if verbose:
         logging.getLogger("flatpak_indexer").setLevel(logging.INFO)
+    if verbose_debug:
+        logging.getLogger("flatpak_indexer").setLevel(logging.DEBUG)
 
 
 @cli.command(name="daemon")

--- a/flatpak_indexer/cli.py
+++ b/flatpak_indexer/cli.py
@@ -17,9 +17,8 @@ logger = logging.getLogger(__name__)
 @click.group()
 @click.pass_context
 @click.option("--config-file", "-c", required=True, help="Config file")
-@click.option("-v", "--verbose", is_flag=True, help="Show verbose info output")
-@click.option("-vv", "--verbose-debug", is_flag=True, help="Show verbose debugging output")
-def cli(ctx, config_file, verbose, verbose_debug):
+@click.option("-v", "--verbose", count=True, help="Show verbose output")
+def cli(ctx, config_file, verbose):
     cfg = Config.from_path(config_file)
 
     ctx.obj = {
@@ -28,9 +27,9 @@ def cli(ctx, config_file, verbose, verbose_debug):
 
     FORMAT = "%(asctime)s:%(levelname)s:%(name)s:%(message)s"
     logging.basicConfig(level=logging.WARNING, format=FORMAT)
-    if verbose:
+    if verbose == 1:
         logging.getLogger("flatpak_indexer").setLevel(logging.INFO)
-    if verbose_debug:
+    elif verbose > 1:
         logging.getLogger("flatpak_indexer").setLevel(logging.DEBUG)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -107,7 +107,7 @@ def test_daemon_exception(tmp_path, where):
 @mock_odcs
 @mock_pyxis
 @mock_redis
-@pytest.mark.parametrize("verbose", [False, True])
+@pytest.mark.parametrize("verbose", [0, 1, 2])
 def test_index(tmp_path, caplog, verbose):
     config_path = write_config(tmp_path, CONFIG)
 
@@ -116,8 +116,10 @@ def test_index(tmp_path, caplog, verbose):
     os.environ["OUTPUT_DIR"] = str(tmp_path)
     runner = CliRunner()
     args = ["--config-file", config_path, "index"]
-    if verbose:
+    if verbose == 1:
         args.insert(0, "--verbose")
+    elif verbose == 2:
+        args.insert(0, "-vv")
     result = runner.invoke(cli, args, catch_exceptions=False)
     os.unlink(config_path)
     if verbose:


### PR DESCRIPTION
Currently the most detailed debug output that could be enabled through cli is INFO, let's add more detailed output that will print DEBUG messages as well.