### PR TITLE
Fix FakeDiffer shutdown race in delta generator tests

### DIFF
--- a/tests/test_delta_generator.py
+++ b/tests/test_delta_generator.py
@@ -157,9 +157,12 @@ class FakeDiffer:
         self.thread = threading.Thread(target=self.run, name="fake-differ")
         self.logger = logging.getLogger(FakeDiffer.__qualname__)
         self.task_destinies = task_destinies
+        self._subscribed = threading.Event()
 
     def __enter__(self):
         self.start()
+        if not self._subscribed.wait(timeout=10.0):
+            raise RuntimeError("FakeDiffer did not subscribe to Redis in time")
 
         return self
 
@@ -271,6 +274,7 @@ class FakeDiffer:
             pubsub = redis_client.pubsub()
             pubsub.subscribe("fake-differ-exit")
             pubsub.subscribe("tardiff:queued")
+            self._subscribed.set()
 
             self._run(redis_client, pubsub)
         except Exception:


### PR DESCRIPTION
The FakeDiffer helper started its pubsub thread and returned from `__enter__` immediately, so tests could call stop() and publish fake-differ-exit before the worker had subscribed. Redis-style pub/sub drops messages with no subscribers, so the worker could block forever in listen() and pytest appeared to hang.

Add a threading.Event set after subscribe() and wait for it in `__enter__`, with a timeout that raises RuntimeError if the worker never becomes ready.