### PR TITLE
Update pyright to 1.1.409 and fix init_value return type

### DIFF
--- a/flatpak_indexer/json_model.py
+++ b/flatpak_indexer/json_model.py
@@ -36,7 +36,7 @@ class ModelField(ABC, Generic[T]):
         self.optional = optional
 
     @abstractmethod
-    def init_value(self, kwargs) -> T: ...
+    def init_value(self, kwargs) -> T | None: ...
 
     @abstractmethod
     def json_include(self, instance) -> bool: ...
@@ -55,7 +55,7 @@ class ScalarField(ModelField[T]):
     @abstractmethod
     def from_json(self, value: Any) -> T: ...
 
-    def init_value(self, kwargs) -> T:
+    def init_value(self, kwargs) -> T | None:
         value = kwargs.get(self.python_name)
         if value is None and not self.optional:
             raise AttributeError(f"{self.json_name} must be specified")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ flatpak-indexer = "flatpak_indexer.cli:cli"
 [dependency-groups]
 dev = [
     "pre-commit>=2.1.1",
-    "pyright>=0.0.13.post0",
+    "pyright>=1.1.409",
     "ruff",
 ]
 


### PR DESCRIPTION
Pyright 1.1.409 correctly flags that ScalarField.init_value can return None when the field is optional. Update the return type annotation to T | None on both the abstract ModelField.init_value and the ScalarField.init_value implementation.