### PR TITLE
tests: Fix SocketBlockedError with redis-py 8 and --disable-socket

### DIFF
--- a/flatpak_indexer/test/redis.py
+++ b/flatpak_indexer/test/redis.py
@@ -48,7 +48,15 @@ def mock_redis(
 
             return fakeredis.FakeStrictRedis(server=server)  # type: ignore
 
-        with patch("redis.Redis.from_url", side_effect=from_url):
+        with (
+            patch("redis.Redis.from_url", side_effect=from_url),
+            # redis-py 8+ tries to resolve the host via socket.getaddrinfo() during
+            # the maintenance notifications handshake, which is blocked by the
+            # --disable-socket pytest flag, raising SocketBlockedError.
+            patch(
+                "redis.connection.Connection.activate_maint_notifications_handling_if_enabled",
+            ),
+        ):
             return f(*args, **kwargs)
 
     return wrapper

--- a/tests/registry.py
+++ b/tests/registry.py
@@ -8,7 +8,7 @@ import json
 import re
 import tarfile
 
-import requests
+from requests import PreparedRequest
 import responses
 
 from flatpak_indexer.test.decorators import WithArgDecorator
@@ -145,23 +145,23 @@ class MockRegistry:
                     ok = True
 
             if not ok:
-                return (requests.codes.UNAUTHORIZED, {}, "")
+                return (401, {}, "")
 
     def _check_bearer_auth(self, req, repo):
         if "bearer_auth" in self.flags:
             authorization = req.headers.get("Authorization")
             if authorization != f"Bearer GOLDEN_LLAMA_{repo}":
                 if "bearer_auth_unknown_type" in self.flags:
-                    return (requests.codes.UNAUTHORIZED, {"WWW-Authenticate": "FeeFiFoFum"}, "")
+                    return (401, {"WWW-Authenticate": "FeeFiFoFum"}, "")
                 elif "bearer_auth_no_realm" in self.flags:
                     return (
-                        requests.codes.UNAUTHORIZED,
+                        401,
                         {"WWW-Authenticate": 'Bearer service="registry.example.com"'},
                         "",
                     )
                 else:
                     return (
-                        requests.codes.UNAUTHORIZED,
+                        401,
                         {
                             "WWW-Authenticate": (
                                 'Bearer realm="https://registry.example.com/token",'
@@ -175,7 +175,7 @@ class MockRegistry:
         url = "https://" + self.hostname
         pat = re.compile("^" + url + pattern + "$")
 
-        def do_it(req):
+        def do_it(req: PreparedRequest) -> tuple[int, dict[str, str], str | bytes]:
             auth_response = self._check_creds(req)
             if auth_response:
                 return auth_response
@@ -200,12 +200,12 @@ class MockRegistry:
             try:
                 ref = repo["tags"][ref]
             except KeyError:
-                return (requests.codes.NOT_FOUND, {}, json_bytes({"error": "NOT_FOUND"}))
+                return (404, {}, json_bytes({"error": "NOT_FOUND"}))
 
         try:
             blob = repo["manifests"][ref]
         except KeyError:
-            return (requests.codes.NOT_FOUND, {}, json_bytes({"error": "NOT_FOUND"}))
+            return (404, {}, json_bytes({"error": "NOT_FOUND"}))
 
         decoded = json.loads(blob)
         content_type = decoded.get("mediaType")
@@ -237,7 +237,7 @@ class MockRegistry:
         try:
             blob = repo["blobs"][digest]
         except KeyError:
-            return (requests.codes.NOT_FOUND, {}, json_bytes({"error": "NOT_FOUND"}))
+            return (404, {}, json_bytes({"error": "NOT_FOUND"}))
 
         headers = {
             "Docker-Content-Digest": digest,


### PR DESCRIPTION
redis-py 8.0.0 auto-enables maintenance notifications, which attempt DNS resolution via socket.getaddrinfo() during connection setup. When fakeredis calls super().connect(), this socket operation is triggered and blocked by pytest-socket's --disable-socket flag, raising SocketBlockedError:

        def _guarded_getaddrinfo(*_args: Any, **_kwargs: Any) -> Any:
    >       raise SocketBlockedError("A test tried to use socket.getaddrinfo.")
    E       pytest_socket.SocketBlockedError: A test tried to use socket.getaddrinfo.

    .venv/lib/python3.12/site-packages/pytest_socket/__init__.py:110: SocketBlockedError

Disabling maintenance notifications via MaintNotificationsConfig(enabled=False) passed to FakeStrictRedis does not work because fakeredis's _CONNECTION_POOL_KWARGS whitelist does not include maint_notifications_config, so the parameter is silently dropped and the pool auto-creates one with enabled="auto" regardless.

Instead, patch out activate_maint_notifications_handling_if_enabled on redis.connection.Connection in the mock_redis decorator. This suppresses the one code path that uses sockets while preserving all other redis-py behavior.

Assisted-by: Cursor